### PR TITLE
web: fix serve regression for 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.0] - Unreleased
+## [0.2.1] - Unreleased
+
+### Fixed
+
+- Fixed the optional Web UI on current FastAPI/Starlette builds. `agent-bus serve` in `0.2.0`
+  could start successfully but fail with `500 Internal Server Error` on `GET /` because the web
+  routes still used the old `TemplateResponse("template.html", context)` calling convention.
+- Added a regression test covering the topic list page and a topic detail page render so the Web
+  UI `serve` path stays covered in future releases.
+
+### Upgrade
+
+- If you already installed `0.2.0` and use the Web UI, upgrade to `0.2.1`.
+- To force `uvx` to refresh a cached `0.2.0` environment, run:
+
+  ```bash
+  uvx --refresh-package agent-bus-mcp --from "agent-bus-mcp[web]==0.2.1" agent-bus serve
+  ```
+
+## [0.2.0]
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-bus-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fastembed",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bus-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Local SQLite-backed MCP server for peer-to-peer agent communication.
 - Optional web UI for browsing/exporting topics
 
 Upgrading from `0.1.x`? See [`CHANGELOG.md`](CHANGELOG.md) for the `0.2.0` migration steps.
+Installed `0.2.0` and use the optional Web UI? Upgrade to `0.2.1` for the `agent-bus serve`
+template-rendering fix.
 
 ## Architecture
 
@@ -248,6 +250,12 @@ From PyPI (no checkout):
 
 ```bash
 uvx --from "agent-bus-mcp[web]" agent-bus serve
+```
+
+If you already cached `0.2.0` via `uvx` and want to force the patch upgrade explicitly:
+
+```bash
+uvx --refresh-package agent-bus-mcp --from "agent-bus-mcp[web]==0.2.1" agent-bus serve
 ```
 
 From GitHub (no checkout, builds from source):

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -84,9 +84,9 @@ async def topics_list(request: Request) -> Any:
     topics = sidebar_topics(db)
 
     return templates.TemplateResponse(
+        request,
         "topics/list.html",
         {
-            "request": request,
             "topics": topics,
             "active_topic_id": None,
             "now": time.time(),
@@ -161,9 +161,9 @@ async def topic_detail(request: Request, topic_id: str, focus: str | None = None
     )
 
     return templates.TemplateResponse(
+        request,
         "topics/detail.html",
         {
-            "request": request,
             "topics": topics,
             "active_topic_id": topic_id,
             "topic": topic,
@@ -221,9 +221,9 @@ async def topic_messages_partial(
     last_seq = messages[-1].seq if messages else None
 
     return templates.TemplateResponse(
+        request,
         "components/messages.html",
         {
-            "request": request,
             "messages": [
                 {
                     "message": msg,
@@ -255,9 +255,9 @@ async def topic_presence_partial(request: Request, topic_id: str) -> Any:
     presence = db.get_presence(topic_id=topic_id, window_seconds=300)
 
     return templates.TemplateResponse(
+        request,
         "components/presence.html",
         {
-            "request": request,
             "presence": presence,
             "now": time.time(),
         },
@@ -324,8 +324,9 @@ async def topic_search(
     query = (q or "").strip()
     if not query:
         return templates.TemplateResponse(
+            request,
             "components/search_results.html",
-            {"request": request, "topic_id": topic_id, "query": "", "results": [], "warnings": []},
+            {"topic_id": topic_id, "query": "", "results": [], "warnings": []},
         )
 
     try:
@@ -342,9 +343,9 @@ async def topic_search(
         )
     except Exception as e:
         return templates.TemplateResponse(
+            request,
             "components/search_results.html",
             {
-                "request": request,
                 "topic_id": topic_id,
                 "query": query,
                 "results": [],
@@ -353,9 +354,9 @@ async def topic_search(
         )
 
     return templates.TemplateResponse(
+        request,
         "components/search_results.html",
         {
-            "request": request,
             "topic_id": topic_id,
             "query": query,
             "results": results,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-bus-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Local SQLite-backed MCP bus for peer coding agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from agent_bus.web import server as web_server
+
+
+def test_web_topics_list_renders(tmp_path: Path) -> None:
+    web_server.init_db(str(tmp_path / "bus.sqlite"))
+    db = web_server.get_db()
+    db.topic_create(name="pink", metadata=None, mode="new")
+
+    with TestClient(web_server.app) as client:
+        res = client.get("/")
+
+    assert res.status_code == 200
+    assert "pink" in res.text
+
+
+def test_web_topic_detail_renders(tmp_path: Path) -> None:
+    web_server.init_db(str(tmp_path / "bus.sqlite"))
+    db = web_server.get_db()
+    topic = db.topic_create(name="pink", metadata=None, mode="new")
+    db.sync_once(
+        topic_id=topic.topic_id,
+        agent_name="alice",
+        outbox=[{"content_markdown": "hello from the web test", "message_type": "message"}],
+        max_items=10,
+        include_self=True,
+        auto_advance=True,
+        ack_through=None,
+    )
+
+    with TestClient(web_server.app) as client:
+        res = client.get(f"/topics/{topic.topic_id}")
+
+    assert res.status_code == 200
+    assert "hello from the web test" in res.text

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agent-bus-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fix the Web UI template rendering regression in `0.2.0` by switching all routes to the request-first `TemplateResponse(...)` signature required by the current FastAPI/Starlette stack
- add a regression test for the topic list page and a topic detail page render
- bump the package/crate version to `0.2.1` and document the patch upgrade path for users who already cached `0.2.0`

## Root cause
`agent-bus serve` in `0.2.0` could start successfully, but `GET /` failed with `500 Internal Server Error` because the web routes still used the older `TemplateResponse("template.html", context)` calling convention. On the current published dependency stack, Starlette expects `TemplateResponse(request, "template.html", context)`.

Closes #7.

## How to test
- `uv run ruff check agent_bus/web/server.py tests/test_web.py`
- `uv run pytest tests/test_web.py`
- `uv run agent-bus serve --port 18080`
- `curl http://127.0.0.1:18080/` and confirm `200 OK`
