### PR TITLE
web: harden SSE shutdown and DB-busy handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ All notable changes to this project will be documented in this file.
   `sync(wait_seconds=0)` for backlog catch-up and an explicit summarize-and-confirm stop before an
   agent starts implementing findings the user did not yet approve.
 
+### Fixed
+
+- `agent-bus serve` now exits on the first `Ctrl+C` even when browser tabs still hold active SSE
+  topic streams open. This local-dev shutdown path now prioritizes returning control to the shell
+  over gracefully draining long-lived browser stream connections.
+- `/api/stream/topics` and `/api/stream/topics/{topic_id}` now treat transient SQLite
+  `DBBusyError` conditions as non-fatal while polling, keeping the SSE stream alive with normal
+  heartbeat behavior instead of crashing with traceback-level noise.
+
 ### Upgrade
 
 - Packaged installs already include the built frontend bundle. If you run from a source checkout,

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import signal
 import time
-from contextlib import asynccontextmanager, suppress
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
@@ -37,13 +37,7 @@ SearchMode = Literal["fts", "semantic", "hybrid"]
 TopicStatusFilter = Literal["open", "closed", "all"]
 TopicSort = Literal["last_updated_desc", "created_desc", "created_asc"]
 
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    yield
-
-
-app = FastAPI(title="Agent Bus", docs_url=None, redoc_url=None, lifespan=lifespan)
+app = FastAPI(title="Agent Bus", docs_url=None, redoc_url=None)
 
 _db: AgentBusDB | None = None
 

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import signal
 import time
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal, cast
@@ -45,6 +46,31 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Agent Bus", docs_url=None, redoc_url=None, lifespan=lifespan)
 
 _db: AgentBusDB | None = None
+
+
+class SSEStreamingResponse(StreamingResponse):
+    async def __call__(self, scope, receive, send) -> None:  # type: ignore[override]
+        try:
+            await super().__call__(scope, receive, send)
+        except asyncio.CancelledError:
+            return
+
+
+class ImmediateSigintServer:
+    def __init__(self, config) -> None:
+        import uvicorn
+
+        class _Server(uvicorn.Server):
+            def handle_exit(self, sig: int, frame) -> None:  # type: ignore[override]
+                self._captured_signals.append(sig)
+                self.should_exit = True
+                if sig == signal.SIGINT:
+                    self.force_exit = True
+
+        self._server = _Server(config=config)
+
+    def run(self) -> None:
+        self._server.run()
 
 
 def get_db() -> AgentBusDB:
@@ -473,7 +499,7 @@ async def api_topics_stream(request: Request) -> StreamingResponse:
         except asyncio.CancelledError:
             return
 
-    return StreamingResponse(
+    return SSEStreamingResponse(
         event_stream(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
@@ -514,7 +540,7 @@ async def api_topic_stream(topic_id: str, request: Request) -> StreamingResponse
         except asyncio.CancelledError:
             return
 
-    return StreamingResponse(
+    return SSEStreamingResponse(
         event_stream(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
@@ -556,9 +582,12 @@ def run_server(host: str = "127.0.0.1", port: int = 8080, db_path: str | None = 
     import uvicorn
 
     init_db(db_path)
-    uvicorn.run(
+    config = uvicorn.Config(
         app,
         host=host,
         port=port,
+        lifespan="off",
         timeout_graceful_shutdown=SERVER_SHUTDOWN_GRACE_SECONDS,
     )
+    with suppress(KeyboardInterrupt):
+        ImmediateSigintServer(config).run()

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -56,8 +56,7 @@ class ImmediateSigintServer:
 
         class _Server(uvicorn.Server):
             def handle_exit(self, sig: int, frame) -> None:  # type: ignore[override]
-                self._captured_signals.append(sig)
-                self.should_exit = True
+                super().handle_exit(sig, frame)
                 if sig == signal.SIGINT:
                     self.force_exit = True
 

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -19,7 +19,7 @@ from fastapi.responses import (
     StreamingResponse,
 )
 
-from agent_bus.db import AgentBusDB, TopicNotFoundError
+from agent_bus.db import AgentBusDB, DBBusyError, TopicNotFoundError
 from agent_bus.models import Cursor, Message
 
 STATIC_DIR = Path(__file__).parent / "static"
@@ -30,6 +30,7 @@ TOPIC_STREAM_INTERVAL_SECONDS = 2.0
 STREAM_HEARTBEAT_SECONDS = 15.0
 PRESENCE_WINDOW_SECONDS = 300
 TOPICS_SIGNATURE_SCAN_LIMIT = 2_147_483_647
+SERVER_SHUTDOWN_GRACE_SECONDS = 2
 
 SearchMode = Literal["fts", "semantic", "hybrid"]
 TopicStatusFilter = Literal["open", "closed", "all"]
@@ -448,20 +449,29 @@ async def api_topics_stream(request: Request) -> StreamingResponse:
     async def event_stream():
         previous_signature: list[TopicSignature] | None = None
         last_heartbeat = 0.0
-        while True:
-            if await request.is_disconnected():
-                return
+        try:
+            while True:
+                if await request.is_disconnected():
+                    return
 
-            signature = topics_signature(db)
-            if signature != previous_signature:
-                previous_signature = signature
-                last_heartbeat = now()
-                yield encode_sse("topics.invalidate", {"timestamp": last_heartbeat})
-            elif now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
-                last_heartbeat = now()
-                yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
+                try:
+                    signature = topics_signature(db)
+                except DBBusyError:
+                    if now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
+                        last_heartbeat = now()
+                        yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
+                else:
+                    if signature != previous_signature:
+                        previous_signature = signature
+                        last_heartbeat = now()
+                        yield encode_sse("topics.invalidate", {"timestamp": last_heartbeat})
+                    elif now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
+                        last_heartbeat = now()
+                        yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
 
-            await asyncio.sleep(TOPICS_STREAM_INTERVAL_SECONDS)
+                await asyncio.sleep(TOPICS_STREAM_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            return
 
     return StreamingResponse(
         event_stream(),
@@ -477,25 +487,32 @@ async def api_topic_stream(topic_id: str, request: Request) -> StreamingResponse
     async def event_stream():
         previous_state: dict[str, Any] | None = None
         last_heartbeat = 0.0
-        while True:
-            if await request.is_disconnected():
-                return
+        try:
+            while True:
+                if await request.is_disconnected():
+                    return
 
-            try:
-                state = topic_stream_state(db, topic_id=topic_id)
-            except TopicNotFoundError:
-                yield encode_sse("topic.deleted", {"topic_id": topic_id})
-                return
+                try:
+                    state = topic_stream_state(db, topic_id=topic_id)
+                except TopicNotFoundError:
+                    yield encode_sse("topic.deleted", {"topic_id": topic_id})
+                    return
+                except DBBusyError:
+                    if now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
+                        last_heartbeat = now()
+                        yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
+                else:
+                    if state != previous_state:
+                        previous_state = state
+                        last_heartbeat = now()
+                        yield encode_sse("topic.update", state)
+                    elif now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
+                        last_heartbeat = now()
+                        yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
 
-            if state != previous_state:
-                previous_state = state
-                last_heartbeat = now()
-                yield encode_sse("topic.update", state)
-            elif now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
-                last_heartbeat = now()
-                yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
-
-            await asyncio.sleep(TOPIC_STREAM_INTERVAL_SECONDS)
+                await asyncio.sleep(TOPIC_STREAM_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            return
 
     return StreamingResponse(
         event_stream(),
@@ -539,4 +556,9 @@ def run_server(host: str = "127.0.0.1", port: int = 8080, db_path: str | None = 
     import uvicorn
 
     init_db(db_path)
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        timeout_graceful_shutdown=SERVER_SHUTDOWN_GRACE_SECONDS,
+    )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -353,7 +353,13 @@ def test_immediate_sigint_server_forces_exit_on_first_interrupt(monkeypatch) -> 
             self._captured_signals = []
             self.should_exit = False
             self.force_exit = False
+            self.super_called = False
             handled["instance"] = self
+
+        def handle_exit(self, sig: int, frame) -> None:
+            self.super_called = True
+            self._captured_signals.append(sig)
+            self.should_exit = True
 
     class FakeUvicorn:
         Server = FakeServer
@@ -364,6 +370,7 @@ def test_immediate_sigint_server_forces_exit_on_first_interrupt(monkeypatch) -> 
     inner = handled["instance"]
     inner.handle_exit(signal.SIGINT, None)
 
+    assert inner.super_called is True
     assert inner.should_exit is True
     assert inner.force_exit is True
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 from datetime import UTC, datetime
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
 
 from agent_bus import db as db_module
 from agent_bus import search as search_module
@@ -312,17 +314,23 @@ def test_run_server_sets_graceful_shutdown_timeout(monkeypatch) -> None:
     def fake_init_db(db_path: str | None = None) -> None:
         calls["db_path"] = db_path
 
-    def fake_uvicorn_run(app, **kwargs) -> None:
-        calls["app"] = app
-        calls["kwargs"] = kwargs
+    class FakeConfig:
+        def __init__(self, app, **kwargs) -> None:
+            calls["app"] = app
+            calls["kwargs"] = kwargs
+            self.app = app
+            self.kwargs = kwargs
 
     class FakeUvicorn:
-        @staticmethod
-        def run(app, **kwargs) -> None:
-            fake_uvicorn_run(app, **kwargs)
+        Config = FakeConfig
 
     monkeypatch.setattr(web_server, "init_db", fake_init_db)
     monkeypatch.setitem(__import__("sys").modules, "uvicorn", FakeUvicorn)
+    monkeypatch.setattr(
+        web_server,
+        "ImmediateSigintServer",
+        lambda config: type("Runner", (), {"run": lambda self: calls.setdefault("ran", config)})(),
+    )
 
     web_server.run_server(host="0.0.0.0", port=9999, db_path="/tmp/test.sqlite")
 
@@ -331,5 +339,47 @@ def test_run_server_sets_graceful_shutdown_timeout(monkeypatch) -> None:
     assert calls["kwargs"] == {
         "host": "0.0.0.0",
         "port": 9999,
+        "lifespan": "off",
         "timeout_graceful_shutdown": web_server.SERVER_SHUTDOWN_GRACE_SECONDS,
     }
+    assert calls["ran"].kwargs == calls["kwargs"]
+
+
+def test_immediate_sigint_server_forces_exit_on_first_interrupt(monkeypatch) -> None:
+    handled: dict[str, object] = {}
+
+    class FakeServer:
+        def __init__(self, config) -> None:
+            self._captured_signals = []
+            self.should_exit = False
+            self.force_exit = False
+            handled["instance"] = self
+
+    class FakeUvicorn:
+        Server = FakeServer
+
+    monkeypatch.setitem(__import__("sys").modules, "uvicorn", FakeUvicorn)
+
+    web_server.ImmediateSigintServer(config=object())
+    inner = handled["instance"]
+    inner.handle_exit(signal.SIGINT, None)
+
+    assert inner.should_exit is True
+    assert inner.force_exit is True
+
+
+def test_sse_streaming_response_swallows_cancelled_error(monkeypatch) -> None:
+    async def fake_super_call(self, scope, receive, send) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(StreamingResponse, "__call__", fake_super_call)
+
+    response = web_server.SSEStreamingResponse(iter(()), media_type="text/event-stream")
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(_message):
+        return None
+
+    asyncio.run(response({"type": "http"}, receive, send))

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -210,6 +210,26 @@ def test_api_topics_stream_uses_sse_framing(tmp_path: Path, monkeypatch) -> None
     assert "event: topics.invalidate" in first_chunk
 
 
+def test_api_topics_stream_survives_db_busy(tmp_path: Path, monkeypatch) -> None:
+    prepare_static_bundle(tmp_path, monkeypatch)
+    install_fake_now(monkeypatch, start=1_700_000_000.0, step=20.0)
+    web_server.init_db(str(tmp_path / "bus.sqlite"))
+
+    class FakeRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    def fake_topics_signature(_db):
+        raise db_module.DBBusyError("database is locked")
+
+    monkeypatch.setattr(web_server, "topics_signature", fake_topics_signature)
+
+    response = asyncio.run(web_server.api_topics_stream(FakeRequest()))
+    first_chunk = asyncio.run(response.body_iterator.__anext__()).decode("utf-8")
+
+    assert "event: heartbeat" in first_chunk
+
+
 def test_topics_signature_changes_after_topic_rename(tmp_path: Path, monkeypatch) -> None:
     prepare_static_bundle(tmp_path, monkeypatch)
     install_fake_now(monkeypatch)
@@ -247,6 +267,29 @@ def test_topic_stream_state_changes_after_non_tail_message_delete(
     assert before != after
 
 
+def test_api_topic_stream_survives_db_busy(tmp_path: Path, monkeypatch) -> None:
+    prepare_static_bundle(tmp_path, monkeypatch)
+    install_fake_now(monkeypatch, start=1_700_000_000.0, step=20.0)
+    web_server.init_db(str(tmp_path / "bus.sqlite"))
+    db = web_server.get_db()
+    topic = db.topic_create(name="pink", metadata=None, mode="new")
+
+    class FakeRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    def fake_topic_stream_state(_db, *, topic_id: str):
+        assert topic_id == topic.topic_id
+        raise db_module.DBBusyError("database is locked")
+
+    monkeypatch.setattr(web_server, "topic_stream_state", fake_topic_stream_state)
+
+    response = asyncio.run(web_server.api_topic_stream(topic.topic_id, FakeRequest()))
+    first_chunk = asyncio.run(response.body_iterator.__anext__()).decode("utf-8")
+
+    assert "event: heartbeat" in first_chunk
+
+
 def test_api_topic_export_uses_iso_timestamps(tmp_path: Path, monkeypatch) -> None:
     prepare_static_bundle(tmp_path, monkeypatch)
     install_fake_now(monkeypatch)
@@ -261,3 +304,32 @@ def test_api_topic_export_uses_iso_timestamps(tmp_path: Path, monkeypatch) -> No
     assert res.status_code == 200
     expected = datetime.fromtimestamp(1_700_000_001, UTC).isoformat().replace("+00:00", "Z")
     assert expected in res.text
+
+
+def test_run_server_sets_graceful_shutdown_timeout(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_init_db(db_path: str | None = None) -> None:
+        calls["db_path"] = db_path
+
+    def fake_uvicorn_run(app, **kwargs) -> None:
+        calls["app"] = app
+        calls["kwargs"] = kwargs
+
+    class FakeUvicorn:
+        @staticmethod
+        def run(app, **kwargs) -> None:
+            fake_uvicorn_run(app, **kwargs)
+
+    monkeypatch.setattr(web_server, "init_db", fake_init_db)
+    monkeypatch.setitem(__import__("sys").modules, "uvicorn", FakeUvicorn)
+
+    web_server.run_server(host="0.0.0.0", port=9999, db_path="/tmp/test.sqlite")
+
+    assert calls["db_path"] == "/tmp/test.sqlite"
+    assert calls["app"] is web_server.app
+    assert calls["kwargs"] == {
+        "host": "0.0.0.0",
+        "port": 9999,
+        "timeout_graceful_shutdown": web_server.SERVER_SHUTDOWN_GRACE_SECONDS,
+    }


### PR DESCRIPTION
## Summary
- harden the web SSE paths so transient `DBBusyError` does not crash topic streams
- make `agent-bus serve` exit on the first `Ctrl+C` even with active SSE clients
- keep the patch scoped to `agent_bus/web/server.py` and `tests/test_web.py`

Closes #19
Closes #20

## Testing
- `uv run pytest tests/test_web.py -q`
- `uv run ruff check agent_bus/web/server.py tests/test_web.py`
- `uv run ruff format --check agent_bus/web/server.py tests/test_web.py`
- manual: run `uv run agent-bus serve`, open `/api/stream/topics`, press `Ctrl+C` once, verify the process exits without repeated interrupts or `kill -9`