### PR TITLE
web: replace topic summary scans with topics_version invalidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ uv sync --extra web     # install Web UI deps
 uv run agent-bus serve  # run Web UI (default http://127.0.0.1:8080)
 uv run ruff format      # format
 uv run ruff check       # lint
+uv run ty check         # static type analysis
 uv run pytest           # tests
 ```
 
@@ -41,7 +42,9 @@ uv run pytest           # tests
 
 Commit history uses lightweight Conventional-ish prefixes (e.g. `feat(web): ...`, `fix(web): ...`, `docs: ...`, `chore: ...`) and component prefixes like `web: ...` / `peer: ...` / `cli: ...`. Follow one of those patterns.
 
-PRs should include: a short description, how to test, and screenshots for Web UI changes. Run `uv run ruff check` and `uv run pytest` before requesting review.
+Before committing code, run `uv run ty check` in addition to the relevant Ruff and pytest commands for the files you touched. Do not skip `ty` just because CI will catch it later.
+
+PRs should include: a short description, how to test, and screenshots for Web UI changes. Run `uv run ty check`, `uv run ruff check`, and `uv run pytest` before requesting review.
 
 ## Security & Configuration Tips
 

--- a/agent_bus/db.py
+++ b/agent_bus/db.py
@@ -189,6 +189,9 @@ class AgentBusDB:
         row["metadata"] = None if metadata_json is None else json_loads(metadata_json)
         return row
 
+    def topic_list_version(self) -> int:
+        return int(self._core.topic_list_version())
+
     def topic_close(self, *, topic_id: str, reason: str | None) -> tuple[Topic, bool]:
         data, already = self._core.topic_close(topic_id, reason)
         return _topic_from_dict(data), bool(already)

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -42,7 +42,7 @@ _db: AgentBusDB | None = None
 
 
 class SSEStreamingResponse(StreamingResponse):
-    async def __call__(self, scope, receive, send) -> None:  # type: ignore[override]
+    async def __call__(self, scope, receive, send) -> None:
         try:
             await super().__call__(scope, receive, send)
         except asyncio.CancelledError:
@@ -54,7 +54,7 @@ class ImmediateSigintServer:
         import uvicorn
 
         class _Server(uvicorn.Server):
-            def handle_exit(self, sig: int, frame) -> None:  # type: ignore[override]
+            def handle_exit(self, sig: int, frame) -> None:
                 super().handle_exit(sig, frame)
                 if sig == signal.SIGINT:
                     self.force_exit = True

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -30,7 +30,6 @@ TOPICS_STREAM_INTERVAL_SECONDS = 2.0
 TOPIC_STREAM_INTERVAL_SECONDS = 2.0
 STREAM_HEARTBEAT_SECONDS = 15.0
 PRESENCE_WINDOW_SECONDS = 300
-TOPICS_SIGNATURE_SCAN_LIMIT = 2_147_483_647
 SERVER_SHUTDOWN_GRACE_SECONDS = 2
 
 SearchMode = Literal["fts", "semantic", "hybrid"]
@@ -236,28 +235,8 @@ def encode_sse(event: str, data: Any) -> bytes:
     return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n".encode()
 
 
-type TopicSignature = tuple[str, str, int, float, str, float | None]
-
-
-def topics_signature(db: AgentBusDB) -> list[TopicSignature]:
-    summaries = list_topic_summaries(
-        db,
-        status="all",
-        sort="last_updated_desc",
-        query="",
-        limit=TOPICS_SIGNATURE_SCAN_LIMIT,
-    )
-    return [
-        (
-            item["topic_id"],
-            item["name"],
-            item["message_count"],
-            item["last_updated_at"],
-            item["status"],
-            item["closed_at"],
-        )
-        for item in summaries
-    ]
+def topics_version(db: AgentBusDB) -> int:
+    return db.topic_list_version()
 
 
 def format_export_timestamp(timestamp: float) -> str:
@@ -466,7 +445,7 @@ async def api_topics_stream(request: Request) -> StreamingResponse:
     db = get_db()
 
     async def event_stream():
-        previous_signature: list[TopicSignature] | None = None
+        previous_version: int | None = None
         last_heartbeat = 0.0
         try:
             while True:
@@ -474,14 +453,14 @@ async def api_topics_stream(request: Request) -> StreamingResponse:
                     return
 
                 try:
-                    signature = topics_signature(db)
+                    version = topics_version(db)
                 except DBBusyError:
                     if now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:
                         last_heartbeat = now()
                         yield encode_sse("heartbeat", {"timestamp": last_heartbeat})
                 else:
-                    if signature != previous_signature:
-                        previous_signature = signature
+                    if version != previous_version:
+                        previous_version = version
                         last_heartbeat = now()
                         yield encode_sse("topics.invalidate", {"timestamp": last_heartbeat})
                     elif now() - last_heartbeat >= STREAM_HEARTBEAT_SECONDS:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2518,7 +2518,7 @@ impl CoreDb {
             }
         }
 
-        conn.execute_batch(&format!(
+        conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS topics (
               topic_id TEXT PRIMARY KEY,
@@ -2581,12 +2581,17 @@ impl CoreDb {
             CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_topic_sender_client_id_unique
               ON messages(topic_id, sender, client_message_id)
               WHERE client_message_id IS NOT NULL;
-            
-            INSERT INTO meta(key, value)
-            VALUES ('{TOPICS_VERSION_META_KEY}', '0')
-            ON CONFLICT(key) DO NOTHING;
             "
-        ))
+        )
+        .map_err(map_db_error)?;
+        conn.execute(
+            "
+            INSERT INTO meta(key, value)
+            VALUES (?, '0')
+            ON CONFLICT(key) DO NOTHING
+            ",
+            params![TOPICS_VERSION_META_KEY],
+        )
         .map_err(map_db_error)?;
 
         self.ensure_search_schema(conn)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ create_exception!(agent_bus_core, TopicMismatchError, PyRuntimeError);
 create_exception!(agent_bus_core, AgentNameInUseError, PyRuntimeError);
 
 const SCHEMA_VERSION: &str = "6";
+const TOPICS_VERSION_META_KEY: &str = "topics_version";
 const DEFAULT_EMBEDDING_MODEL: &str = "BAAI/bge-small-en-v1.5";
 const DEFAULT_MAX_TOKENS: usize = 512;
 const MAX_EMBEDDING_MAX_TOKENS: usize = 8192;
@@ -1192,6 +1193,7 @@ impl CoreDb {
             params![topic_id, topic_name, created_at, metadata_json],
         )
         .map_err(map_db_error)?;
+        bump_topics_version(&tx).map_err(map_db_error)?;
         tx.commit().map_err(map_db_error)?;
 
         let topic = TopicRow {
@@ -1326,6 +1328,20 @@ impl CoreDb {
         Ok(out.into())
     }
 
+    fn topic_list_version(&self) -> PyResult<i64> {
+        let conn = self.connect()?;
+        let version = conn
+            .query_row(
+                "SELECT CAST(value AS INTEGER) FROM meta WHERE key = ?",
+                params![TOPICS_VERSION_META_KEY],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_db_error)?
+            .unwrap_or(0);
+        Ok(version)
+    }
+
     fn topic_get_with_counts(&self, py: Python<'_>, topic_id: String) -> PyResult<Py<PyAny>> {
         let conn = self.connect()?;
         let row = conn
@@ -1409,6 +1425,7 @@ impl CoreDb {
             params![closed_at, close_reason, existing.topic_id],
         )
         .map_err(map_db_error)?;
+        bump_topics_version(&tx).map_err(map_db_error)?;
         tx.commit().map_err(map_db_error)?;
 
         let updated = TopicRow {
@@ -1457,6 +1474,7 @@ impl CoreDb {
         .map_err(map_db_error)?;
         tx.execute("DELETE FROM topics WHERE topic_id = ?", params![topic_id])
             .map_err(map_db_error)?;
+        bump_topics_version(&tx).map_err(map_db_error)?;
         tx.commit().map_err(map_db_error)?;
         Ok(true)
     }
@@ -1536,6 +1554,7 @@ impl CoreDb {
             }
         }
 
+        bump_topics_version(&tx).map_err(map_db_error)?;
         tx.commit().map_err(map_db_error)?;
         let updated = TopicRow {
             topic_id: existing.topic_id,
@@ -1601,6 +1620,7 @@ impl CoreDb {
         let delete_sql = format!("DELETE FROM messages WHERE message_id IN ({placeholders})");
         tx.execute(&delete_sql, params_from_iter(rows.iter()))
             .map_err(map_db_error)?;
+        bump_topics_version(&tx).map_err(map_db_error)?;
         tx.commit().map_err(map_db_error)?;
         Ok(rows.len() as i64)
     }
@@ -1660,6 +1680,7 @@ impl CoreDb {
             format!("DELETE FROM messages WHERE message_id IN ({delete_placeholders})");
         tx.execute(&delete_sql, params_from_iter(rows.iter()))
             .map_err(map_db_error)?;
+        bump_topics_version(&tx).map_err(map_db_error)?;
         tx.commit().map_err(map_db_error)?;
 
         let out = PyList::empty(py);
@@ -1879,6 +1900,7 @@ impl CoreDb {
         let mut next_seq = next_seq;
 
         let mut sent: Vec<(MessageRow, bool)> = Vec::new();
+        let mut inserted_messages = false;
         for item in outbox {
             if let Some(client_message_id) = item.client_message_id.clone() {
                 let existing = tx
@@ -1969,6 +1991,7 @@ impl CoreDb {
                 },
                 false,
             ));
+            inserted_messages = true;
         }
 
         tx.execute(
@@ -2076,6 +2099,9 @@ impl CoreDb {
             cursor.updated_at = updated_at;
         }
 
+        if inserted_messages {
+            bump_topics_version(&tx).map_err(map_db_error)?;
+        }
         tx.commit().map_err(map_db_error)?;
 
         let sent_py = PyList::empty(py);
@@ -2470,7 +2496,9 @@ impl CoreDb {
                 );
 
                 INSERT INTO meta(key, value)
-                VALUES ('schema_version', '{SCHEMA_VERSION}');
+                VALUES
+                  ('schema_version', '{SCHEMA_VERSION}'),
+                  ('{TOPICS_VERSION_META_KEY}', '0');
                 "
             ))
             .map_err(map_db_error)?;
@@ -2490,7 +2518,7 @@ impl CoreDb {
             }
         }
 
-        conn.execute_batch(
+        conn.execute_batch(&format!(
             "
             CREATE TABLE IF NOT EXISTS topics (
               topic_id TEXT PRIMARY KEY,
@@ -2553,8 +2581,12 @@ impl CoreDb {
             CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_topic_sender_client_id_unique
               ON messages(topic_id, sender, client_message_id)
               WHERE client_message_id IS NOT NULL;
-            ",
-        )
+            
+            INSERT INTO meta(key, value)
+            VALUES ('{TOPICS_VERSION_META_KEY}', '0')
+            ON CONFLICT(key) DO NOTHING;
+            "
+        ))
         .map_err(map_db_error)?;
 
         self.ensure_search_schema(conn)?;
@@ -2740,6 +2772,18 @@ fn new_reclaim_token() -> String {
 
 fn new_id() -> String {
     Uuid::new_v4().simple().to_string()[0..10].to_string()
+}
+
+fn bump_topics_version(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<()> {
+    tx.execute(
+        "
+        UPDATE meta
+        SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
+        WHERE key = ?
+        ",
+        params![TOPICS_VERSION_META_KEY],
+    )?;
+    Ok(())
 }
 
 fn ensure_parent_dir(path: &str) -> std::io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2581,7 +2581,7 @@ impl CoreDb {
             CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_topic_sender_client_id_unique
               ON messages(topic_id, sender, client_message_id)
               WHERE client_message_id IS NOT NULL;
-            "
+            ",
         )
         .map_err(map_db_error)?;
         conn.execute(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2599,7 +2599,7 @@ impl CoreDb {
         if needs_topics_version_backfill {
             conn.execute(
                 "
-                INSERT INTO meta(key, value)
+                INSERT OR IGNORE INTO meta(key, value)
                 VALUES (?, '0')
                 ",
                 params![TOPICS_VERSION_META_KEY],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2777,9 +2777,9 @@ fn new_id() -> String {
 fn bump_topics_version(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<()> {
     tx.execute(
         "
-        UPDATE meta
-        SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
-        WHERE key = ?
+        INSERT INTO meta(key, value) VALUES (?, '1')
+        ON CONFLICT(key) DO UPDATE
+          SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
         ",
         params![TOPICS_VERSION_META_KEY],
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2482,6 +2482,8 @@ impl CoreDb {
             .collect::<Result<Vec<_>, _>>()
             .map_err(map_db_error)?;
 
+        let mut needs_topics_version_backfill = false;
+
         if !rows.iter().any(|n| n == "meta") {
             if !rows.is_empty() {
                 return Err(SchemaMismatchError::new_err(
@@ -2516,6 +2518,16 @@ impl CoreDb {
                     "Database schema version mismatch. Wipe it with `agent-bus cli db wipe --yes` or delete the file at $AGENT_BUS_DB.",
                 ));
             }
+
+            needs_topics_version_backfill = conn
+                .query_row(
+                    "SELECT 1 FROM meta WHERE key = ? LIMIT 1",
+                    params![TOPICS_VERSION_META_KEY],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map_err(map_db_error)?
+                .is_none();
         }
 
         conn.execute_batch(
@@ -2584,15 +2596,16 @@ impl CoreDb {
             ",
         )
         .map_err(map_db_error)?;
-        conn.execute(
-            "
-            INSERT INTO meta(key, value)
-            VALUES (?, '0')
-            ON CONFLICT(key) DO NOTHING
-            ",
-            params![TOPICS_VERSION_META_KEY],
-        )
-        .map_err(map_db_error)?;
+        if needs_topics_version_backfill {
+            conn.execute(
+                "
+                INSERT INTO meta(key, value)
+                VALUES (?, '0')
+                ",
+                params![TOPICS_VERSION_META_KEY],
+            )
+            .map_err(map_db_error)?;
+        }
 
         self.ensure_search_schema(conn)?;
         self.ensure_embeddings_schema(conn)?;

--- a/tests/test_db_latest.py
+++ b/tests/test_db_latest.py
@@ -153,3 +153,88 @@ def test_topic_list_with_counts_defaults_to_created_desc_sort(tmp_path, monkeypa
     topics = db.topic_list_with_counts(status="all", limit=10)
 
     assert [topic["topic_id"] for topic in topics[:2]] == [second.topic_id, first.topic_id]
+
+
+def test_topic_list_version_bumps_for_topic_list_mutations(tmp_path, monkeypatch):
+    install_fake_now(monkeypatch)
+    db = AgentBusDB(path=str(tmp_path / "bus.sqlite"))
+
+    assert db.topic_list_version() == 0
+
+    topic = db.topic_create(name="alpha", metadata=None, mode="new")
+    assert db.topic_list_version() == 1
+
+    db.topic_rename(topic_id=topic.topic_id, new_name="beta", rewrite_messages=False)
+    assert db.topic_list_version() == 2
+
+    db.sync_once(
+        topic_id=topic.topic_id,
+        agent_name="reviewer",
+        outbox=[
+            {
+                "content_markdown": "hello",
+                "message_type": "message",
+                "reply_to": None,
+                "metadata": None,
+                "client_message_id": None,
+            }
+        ],
+        max_items=20,
+        include_self=True,
+        auto_advance=True,
+        ack_through=None,
+    )
+    assert db.topic_list_version() == 3
+
+    message = db.get_latest_messages(topic_id=topic.topic_id, limit=1)[0]
+    db.delete_message(message_id=message.message_id)
+    assert db.topic_list_version() == 4
+
+    for content in ("one", "two"):
+        db.sync_once(
+            topic_id=topic.topic_id,
+            agent_name="reviewer",
+            outbox=[
+                {
+                    "content_markdown": content,
+                    "message_type": "message",
+                    "reply_to": None,
+                    "metadata": None,
+                    "client_message_id": None,
+                }
+            ],
+            max_items=20,
+            include_self=True,
+            auto_advance=True,
+            ack_through=None,
+        )
+    assert db.topic_list_version() == 6
+
+    messages = db.get_messages(topic_id=topic.topic_id, limit=20)
+    db.delete_messages_batch(topic_id=topic.topic_id, message_ids=[messages[0].message_id])
+    assert db.topic_list_version() == 7
+
+    db.topic_close(topic_id=topic.topic_id, reason="done")
+    assert db.topic_list_version() == 8
+
+    assert db.delete_topic(topic_id=topic.topic_id) is True
+    assert db.topic_list_version() == 9
+
+
+def test_topic_list_version_ignores_cursor_only_sync(tmp_path, monkeypatch):
+    install_fake_now(monkeypatch)
+    db = AgentBusDB(path=str(tmp_path / "bus.sqlite"))
+    topic = db.topic_create(name="alpha", metadata=None, mode="new")
+    starting_version = db.topic_list_version()
+
+    db.sync_once(
+        topic_id=topic.topic_id,
+        agent_name="reviewer",
+        outbox=[],
+        max_items=20,
+        include_self=True,
+        auto_advance=True,
+        ack_through=None,
+    )
+
+    assert db.topic_list_version() == starting_version

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -221,10 +221,10 @@ def test_api_topics_stream_survives_db_busy(tmp_path: Path, monkeypatch) -> None
         async def is_disconnected(self) -> bool:
             return False
 
-    def fake_topics_signature(_db):
+    def fake_topics_version(_db):
         raise db_module.DBBusyError("database is locked")
 
-    monkeypatch.setattr(web_server, "topics_signature", fake_topics_signature)
+    monkeypatch.setattr(web_server, "topics_version", fake_topics_version)
 
     response = asyncio.run(web_server.api_topics_stream(FakeRequest()))
     first_chunk = asyncio.run(response.body_iterator.__anext__()).decode("utf-8")
@@ -232,19 +232,18 @@ def test_api_topics_stream_survives_db_busy(tmp_path: Path, monkeypatch) -> None
     assert "event: heartbeat" in first_chunk
 
 
-def test_topics_signature_changes_after_topic_rename(tmp_path: Path, monkeypatch) -> None:
+def test_topics_version_changes_after_topic_rename(tmp_path: Path, monkeypatch) -> None:
     prepare_static_bundle(tmp_path, monkeypatch)
     install_fake_now(monkeypatch)
     web_server.init_db(str(tmp_path / "bus.sqlite"))
     db = web_server.get_db()
     topic = db.topic_create(name="before", metadata=None, mode="new")
 
-    before = web_server.topics_signature(db)
+    before = web_server.topics_version(db)
     db.topic_rename(topic_id=topic.topic_id, new_name="after", rewrite_messages=False)
-    after = web_server.topics_signature(db)
+    after = web_server.topics_version(db)
 
-    assert before != after
-    assert any(item[0] == topic.topic_id and item[1] == "after" for item in after)
+    assert after == before + 1
 
 
 def test_topic_stream_state_changes_after_non_tail_message_delete(


### PR DESCRIPTION
## Summary
- replace /api/stream/topics full-summary polling with a cheap topics_version read
- bump topics_version only on topic-list-affecting writes in the core DB
- keep the SPA/browser contract unchanged by continuing to emit topics.invalidate

Closes #17

## How to test
- uv run maturin develop
- cargo check
- uv run pytest tests/test_db_latest.py tests/test_web.py -q
- uv run ruff check agent_bus/web/server.py agent_bus/db.py tests/test_db_latest.py tests/test_web.py
- uv run ruff format --check agent_bus/web/server.py agent_bus/db.py tests/test_db_latest.py tests/test_web.py
