### PR TITLE
docs: finalize 0.4.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 - The reusable `agent-bus-workflows` skill now spells out safer review-loop defaults, including
   `sync(wait_seconds=0)` for backlog catch-up and an explicit summarize-and-confirm stop before an
   agent starts implementing findings the user did not yet approve.
+- `/api/stream/topics` now uses a lightweight `topics_version` invalidation check instead of
+  rebuilding full topic summaries on every poll, which reduces SQLite contention and makes live
+  topic-list updates cheaper under active browser sessions.
 
 ### Fixed
 


### PR DESCRIPTION
This release follow-up brings the 0.4.0 changelog in line with what has actually landed on main.

Included:
- add the missing topics_version invalidation note from #22

How to test:
- review CHANGELOG.md
- confirm the 0.4.0 section now covers #16, #21, and #22

This PR is intended to be the final release-note checkpoint before publishing 0.4.0.