### PR TITLE
embeddings: fix idle lease churn and atomic claims

### DIFF
--- a/agent_bus/db.py
+++ b/agent_bus/db.py
@@ -126,11 +126,57 @@ class AgentBusDB:
             max_attempts,
         )
 
+    def has_ready_embedding_jobs(
+        self,
+        *,
+        model: str,
+        limit: int,
+        lock_ttl_seconds: int,
+        error_retry_seconds: int,
+        max_attempts: int,
+    ) -> bool:
+        return bool(
+            self._core.has_ready_embedding_jobs(
+                model,
+                int(limit),
+                int(lock_ttl_seconds),
+                int(error_retry_seconds),
+                int(max_attempts),
+            )
+        )
+
+    def claim_embedding_jobs_if_leader(
+        self,
+        *,
+        model: str,
+        limit: int,
+        lock_ttl_seconds: int,
+        error_retry_seconds: int,
+        max_attempts: int,
+        leader_ttl_seconds: int,
+        leader_heartbeat_seconds: int,
+    ) -> list[dict[str, Any]]:
+        return self._core.claim_embedding_jobs_if_leader(
+            model,
+            int(limit),
+            int(lock_ttl_seconds),
+            int(error_retry_seconds),
+            int(max_attempts),
+            int(leader_ttl_seconds),
+            int(leader_heartbeat_seconds),
+        )
+
     def claim_embedding_leader(self, *, worker_id: str, ttl_seconds: int) -> bool:
         return bool(self._core.claim_embedding_leader(worker_id, int(ttl_seconds)))
 
+    def renew_embedding_leader_self(self, *, ttl_seconds: int) -> bool:
+        return bool(self._core.renew_embedding_leader_self(int(ttl_seconds)))
+
     def release_embedding_leader(self, *, worker_id: str) -> bool:
         return bool(self._core.release_embedding_leader(worker_id))
+
+    def release_embedding_leader_self(self) -> bool:
+        return bool(self._core.release_embedding_leader_self())
 
     def complete_embedding_job(self, *, message_id: str, model: str) -> None:
         self._core.complete_embedding_job(message_id, model)

--- a/agent_bus/embedding_worker.py
+++ b/agent_bus/embedding_worker.py
@@ -195,58 +195,86 @@ def _worker_loop(
         return _core.embed_texts(texts, model=selected_model)
 
     next_heartbeat_at = 0.0
-    has_leader = False
+    has_self_lease = False
+    idle_sleep_seconds = poll_seconds
 
-    def _heartbeat() -> bool:
-        nonlocal next_heartbeat_at, has_leader
-        claimed = db.claim_embedding_leader(worker_id=worker_id, ttl_seconds=leader_ttl_seconds)
-        has_leader = claimed
-        if claimed:
-            next_heartbeat_at = time.monotonic() + leader_heartbeat_seconds
-        return claimed
+    def _sleep_with_backoff() -> None:
+        nonlocal idle_sleep_seconds
+        stop_event.wait(idle_sleep_seconds)
+        idle_sleep_seconds = min(idle_sleep_seconds * 2, 1.0)
+
+    def _reset_backoff() -> None:
+        nonlocal idle_sleep_seconds
+        idle_sleep_seconds = poll_seconds
+
+    def _release_self_lease() -> None:
+        nonlocal has_self_lease, next_heartbeat_at
+        if not has_self_lease:
+            return
+        with suppress(Exception):
+            db.release_embedding_leader_self()
+        has_self_lease = False
+        next_heartbeat_at = 0.0
+
+    def _maybe_heartbeat() -> bool:
+        nonlocal next_heartbeat_at
+        if time.monotonic() < next_heartbeat_at:
+            return True
+        if not db.renew_embedding_leader_self(ttl_seconds=leader_ttl_seconds):
+            return False
+        next_heartbeat_at = time.monotonic() + leader_heartbeat_seconds
+        return True
 
     try:
         while not stop_event.is_set():
             try:
-                if not has_leader:
-                    if not _heartbeat():
-                        stop_event.wait(poll_seconds)
-                        continue
-                elif time.monotonic() >= next_heartbeat_at and not _heartbeat():
-                    stop_event.wait(poll_seconds)
-                    continue
-
-                jobs = db.claim_embedding_jobs(
+                if not db.has_ready_embedding_jobs(
                     model=model,
                     limit=batch_size,
-                    worker_id=worker_id,
                     lock_ttl_seconds=lock_ttl_seconds,
                     error_retry_seconds=error_retry_seconds,
                     max_attempts=max_attempts,
+                ):
+                    # Only release after we have actually held the self-lease.
+                    _release_self_lease()
+                    _sleep_with_backoff()
+                    continue
+
+                jobs = db.claim_embedding_jobs_if_leader(
+                    model=model,
+                    limit=batch_size,
+                    lock_ttl_seconds=lock_ttl_seconds,
+                    error_retry_seconds=error_retry_seconds,
+                    max_attempts=max_attempts,
+                    leader_ttl_seconds=leader_ttl_seconds,
+                    leader_heartbeat_seconds=leader_heartbeat_seconds,
                 )
             except (SchemaMismatchError, ValueError):
                 return
             except DBBusyError:
-                stop_event.wait(poll_seconds)
+                _sleep_with_backoff()
                 continue
             except Exception:  # pragma: no cover
-                stop_event.wait(poll_seconds)
+                _sleep_with_backoff()
                 continue
 
             if not jobs:
-                if has_leader:
-                    with suppress(Exception):
-                        db.release_embedding_leader(worker_id=worker_id)
-                    has_leader = False
-                    next_heartbeat_at = 0.0
-                stop_event.wait(poll_seconds)
+                # The Rust helper already handled any required cleanup for the empty batch.
+                has_self_lease = False
+                next_heartbeat_at = 0.0
+                _sleep_with_backoff()
                 continue
+
+            has_self_lease = True
+            _reset_backoff()
+            next_heartbeat_at = time.monotonic() + leader_heartbeat_seconds
 
             for job in jobs:
                 if stop_event.is_set():
                     return
-                if time.monotonic() >= next_heartbeat_at and not _heartbeat():
-                    stop_event.wait(poll_seconds)
+                if not _maybe_heartbeat():
+                    _release_self_lease()
+                    _sleep_with_backoff()
                     break
 
                 message_id = str(job["message_id"])
@@ -283,8 +311,7 @@ def _worker_loop(
             # Avoid a tight loop when there is always work (and allow other DB users to make progress).
             stop_event.wait(0.01)
     finally:
-        with suppress(Exception):
-            db.release_embedding_leader(worker_id=worker_id)
+        _release_self_lease()
 
 
 _worker_lock = threading.Lock()

--- a/agent_bus/embedding_worker.py
+++ b/agent_bus/embedding_worker.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import threading
 import time
-import uuid
 from collections.abc import Callable
 from contextlib import suppress
 from typing import Any
@@ -176,7 +175,6 @@ def index_message_rows(
 def _worker_loop(
     *,
     db: AgentBusDB,
-    worker_id: str,
     model: str,
     chunk_size: int,
     chunk_overlap: int,
@@ -352,12 +350,10 @@ def start_background_embedding_worker(db: AgentBusDB) -> None:
         poll_seconds = poll_ms / 1000.0
 
         stop_event = threading.Event()
-        worker_id = uuid.uuid4().hex[:8]
         t = threading.Thread(
             target=_worker_loop,
             kwargs={
                 "db": db,
-                "worker_id": worker_id,
                 "model": model,
                 "chunk_size": chunk_size,
                 "chunk_overlap": chunk_overlap,

--- a/agent_bus/embedding_worker.py
+++ b/agent_bus/embedding_worker.py
@@ -197,11 +197,12 @@ def _worker_loop(
     next_heartbeat_at = 0.0
     has_self_lease = False
     idle_sleep_seconds = poll_seconds
+    idle_sleep_cap = max(poll_seconds, 1.0)
 
     def _sleep_with_backoff() -> None:
         nonlocal idle_sleep_seconds
         stop_event.wait(idle_sleep_seconds)
-        idle_sleep_seconds = min(idle_sleep_seconds * 2, 1.0)
+        idle_sleep_seconds = min(idle_sleep_seconds * 2, idle_sleep_cap)
 
     def _reset_backoff() -> None:
         nonlocal idle_sleep_seconds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,8 @@ fn embed_texts(
 struct CoreDb {
     path: String,
     fts_available: Mutex<Option<bool>>,
+    leader_id: String,
+    leader_last_heartbeat: Mutex<Option<f64>>,
 }
 
 #[pymethods]
@@ -418,6 +420,8 @@ impl CoreDb {
         Ok(Self {
             path: resolved,
             fts_available: Mutex::new(None),
+            leader_id: new_id(),
+            leader_last_heartbeat: Mutex::new(None),
         })
     }
 
@@ -825,120 +829,185 @@ impl CoreDb {
         let conn = self.connect()?;
         conn.execute_batch("BEGIN IMMEDIATE")
             .map_err(map_db_error)?;
-
-        let claimed_at = now();
-        let stale_before = claimed_at - lock_ttl_seconds as f64;
-        let error_ready_before = claimed_at - error_retry_seconds as f64;
-
-        let mut stmt = conn
-            .prepare(
-                "
-                SELECT message_id, topic_id
-                FROM embedding_jobs
-                WHERE model = ?
-                  AND attempts < ?
-                  AND (
-                    status = 'pending'
-                    OR (status = 'error' AND updated_at <= ?)
-                    OR (status = 'processing' AND (locked_at IS NULL OR locked_at <= ?))
-                  )
-                ORDER BY updated_at ASC
-                LIMIT ?
-                ",
-            )
-            .map_err(map_db_error)?;
-
-        let rows: Vec<(String, String)> = stmt
-            .query_map(
-                params![
-                    model,
-                    max_attempts,
-                    error_ready_before,
-                    stale_before,
-                    limit as i64
-                ],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .map_err(map_db_error)?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(map_db_error)?;
-
-        if rows.is_empty() {
-            conn.execute_batch("COMMIT").map_err(map_db_error)?;
-            return Ok(PyList::empty(py).into());
-        }
-
-        let message_ids: Vec<String> = rows.iter().map(|(m, _)| m.clone()).collect();
-        let placeholders = placeholders(message_ids.len());
-
-        let mut params_vec: Vec<Value> = vec![
-            Value::from(worker_id.clone()),
-            Value::from(claimed_at),
-            Value::from(claimed_at),
-            Value::from(model.clone()),
-            Value::from(max_attempts),
-            Value::from(error_ready_before),
-            Value::from(stale_before),
-        ];
-        for mid in &message_ids {
-            params_vec.push(Value::from(mid.clone()));
-        }
-
-        let update_sql = format!(
-            "
-            UPDATE embedding_jobs
-            SET
-              status = 'processing',
-              locked_by = ?,
-              locked_at = ?,
-              updated_at = ?,
-              attempts = attempts + 1
-            WHERE model = ?
-              AND attempts < ?
-              AND (
-                status = 'pending'
-                OR (status = 'error' AND updated_at <= ?)
-                OR (status = 'processing' AND (locked_at IS NULL OR locked_at <= ?))
-              )
-              AND message_id IN ({placeholders})
-            "
-        );
-
-        conn.execute(&update_sql, params_from_iter(params_vec.iter()))
-            .map_err(map_db_error)?;
-
-        let mut stmt = conn
-            .prepare(
-                "
-                SELECT message_id, topic_id, attempts
-                FROM embedding_jobs
-                WHERE model = ? AND locked_by = ? AND locked_at = ?
-                ",
-            )
-            .map_err(map_db_error)?;
-        let claimed_rows = stmt
-            .query_map(params![model, worker_id, claimed_at], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, i64>(2)?,
-                ))
-            })
-            .map_err(map_db_error)?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(map_db_error)?;
-
+        let claimed_rows = claim_embedding_jobs_in_tx(
+            &conn,
+            &model,
+            limit,
+            &worker_id,
+            lock_ttl_seconds,
+            error_retry_seconds,
+            max_attempts,
+        )
+        .map_err(map_db_error)?;
         conn.execute_batch("COMMIT").map_err(map_db_error)?;
+        claimed_rows_to_py(py, claimed_rows)
+    }
 
-        let out = PyList::empty(py);
-        for (mid, tid, attempts) in claimed_rows {
-            let dict = PyDict::new(py);
-            dict.set_item("message_id", mid)?;
-            dict.set_item("topic_id", tid)?;
-            dict.set_item("attempts", attempts)?;
-            out.append(dict)?;
+    #[allow(clippy::too_many_arguments)]
+    fn has_ready_embedding_jobs(
+        &self,
+        model: String,
+        limit: usize,
+        lock_ttl_seconds: i64,
+        error_retry_seconds: i64,
+        max_attempts: i64,
+    ) -> PyResult<bool> {
+        if limit == 0 {
+            return Err(PyValueError::new_err("limit must be > 0"));
         }
-        Ok(out.into())
+        if lock_ttl_seconds <= 0 {
+            return Err(PyValueError::new_err("lock_ttl_seconds must be > 0"));
+        }
+        if error_retry_seconds < 0 {
+            return Err(PyValueError::new_err("error_retry_seconds must be >= 0"));
+        }
+        if max_attempts <= 0 {
+            return Err(PyValueError::new_err("max_attempts must be > 0"));
+        }
+
+        let conn = self.connect()?;
+        has_ready_embedding_jobs_in_tx(
+            &conn,
+            &model,
+            limit,
+            lock_ttl_seconds,
+            error_retry_seconds,
+            max_attempts,
+        )
+        .map_err(map_db_error)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn claim_embedding_jobs_if_leader(
+        &self,
+        py: Python<'_>,
+        model: String,
+        limit: usize,
+        lock_ttl_seconds: i64,
+        error_retry_seconds: i64,
+        max_attempts: i64,
+        leader_ttl_seconds: i64,
+        leader_heartbeat_seconds: i64,
+    ) -> PyResult<Py<PyAny>> {
+        if limit == 0 {
+            return Err(PyValueError::new_err("limit must be > 0"));
+        }
+        if lock_ttl_seconds <= 0 {
+            return Err(PyValueError::new_err("lock_ttl_seconds must be > 0"));
+        }
+        if error_retry_seconds < 0 {
+            return Err(PyValueError::new_err("error_retry_seconds must be >= 0"));
+        }
+        if max_attempts <= 0 {
+            return Err(PyValueError::new_err("max_attempts must be > 0"));
+        }
+        if leader_ttl_seconds <= 0 {
+            return Err(PyValueError::new_err("leader_ttl_seconds must be > 0"));
+        }
+        if leader_heartbeat_seconds <= 0 {
+            return Err(PyValueError::new_err(
+                "leader_heartbeat_seconds must be > 0",
+            ));
+        }
+
+        let conn = self.connect()?;
+        conn.execute_batch("BEGIN IMMEDIATE")
+            .map_err(map_db_error)?;
+
+        let result: PyResult<Py<PyAny>> = (|| {
+            if !self.ensure_embedding_leader_self(
+                &conn,
+                leader_ttl_seconds,
+                leader_heartbeat_seconds,
+            )? {
+                conn.execute_batch("COMMIT").map_err(map_db_error)?;
+                return Ok(PyList::empty(py).into());
+            }
+
+            let claimed_rows = claim_embedding_jobs_in_tx(
+                &conn,
+                &model,
+                limit,
+                &self.leader_id,
+                lock_ttl_seconds,
+                error_retry_seconds,
+                max_attempts,
+            )
+            .map_err(map_db_error)?;
+
+            if claimed_rows.is_empty() {
+                release_embedding_leader_in_tx(&conn, &self.leader_id).map_err(map_db_error)?;
+                if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                    *last_heartbeat = None;
+                }
+                conn.execute_batch("COMMIT").map_err(map_db_error)?;
+                return Ok(PyList::empty(py).into());
+            }
+
+            conn.execute_batch("COMMIT").map_err(map_db_error)?;
+            Ok(claimed_rows_to_py(py, claimed_rows)?)
+        })();
+
+        if result.is_err() {
+            if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                *last_heartbeat = None;
+            }
+        }
+        result
+    }
+
+    fn renew_embedding_leader_self(&self, ttl_seconds: i64) -> PyResult<bool> {
+        if ttl_seconds <= 0 {
+            return Err(PyValueError::new_err("ttl_seconds must be > 0"));
+        }
+
+        let conn = self.connect()?;
+        conn.execute_batch("BEGIN IMMEDIATE")
+            .map_err(map_db_error)?;
+
+        let result = (|| {
+            let updated = claim_embedding_leader_in_tx(&conn, &self.leader_id, ttl_seconds)
+                .map_err(map_db_error)?;
+            conn.execute_batch("COMMIT").map_err(map_db_error)?;
+            if updated {
+                if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                    *last_heartbeat = Some(now());
+                }
+            } else if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                *last_heartbeat = None;
+            }
+            Ok(updated)
+        })();
+
+        if result.is_err() {
+            if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                *last_heartbeat = None;
+            }
+        }
+        result
+    }
+
+    fn release_embedding_leader_self(&self) -> PyResult<bool> {
+        let conn = self.connect()?;
+        conn.execute_batch("BEGIN IMMEDIATE")
+            .map_err(map_db_error)?;
+
+        let result = (|| {
+            let updated =
+                release_embedding_leader_in_tx(&conn, &self.leader_id).map_err(map_db_error)?;
+            conn.execute_batch("COMMIT").map_err(map_db_error)?;
+            if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                *last_heartbeat = None;
+            }
+            Ok(updated)
+        })();
+
+        if result.is_err() {
+            if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
+                *last_heartbeat = None;
+            }
+        }
+        result
     }
 
     fn claim_embedding_leader(&self, worker_id: String, ttl_seconds: i64) -> PyResult<bool> {
@@ -949,52 +1018,19 @@ impl CoreDb {
         let conn = self.connect()?;
         conn.execute_batch("BEGIN IMMEDIATE")
             .map_err(map_db_error)?;
-
-        conn.execute(
-            "
-            INSERT OR IGNORE INTO embedding_worker_leader(id, leader_id, heartbeat_at, expires_at)
-            VALUES (1, '', 0, 0)
-            ",
-            [],
-        )
-        .map_err(map_db_error)?;
-
-        let now_ts = now();
-        let expires_at = now_ts + ttl_seconds as f64;
-        let updated = conn
-            .execute(
-                "
-                UPDATE embedding_worker_leader
-                SET leader_id = ?, heartbeat_at = ?, expires_at = ?
-                WHERE id = 1 AND (leader_id = ? OR expires_at <= ?)
-                ",
-                params![worker_id, now_ts, expires_at, worker_id, now_ts],
-            )
-            .map_err(map_db_error)?;
-
+        let updated =
+            claim_embedding_leader_in_tx(&conn, &worker_id, ttl_seconds).map_err(map_db_error)?;
         conn.execute_batch("COMMIT").map_err(map_db_error)?;
-        Ok(updated == 1)
+        Ok(updated)
     }
 
     fn release_embedding_leader(&self, worker_id: String) -> PyResult<bool> {
         let conn = self.connect()?;
         conn.execute_batch("BEGIN IMMEDIATE")
             .map_err(map_db_error)?;
-
-        let now_ts = now();
-        let updated = conn
-            .execute(
-                "
-                UPDATE embedding_worker_leader
-                SET leader_id = '', heartbeat_at = ?, expires_at = ?
-                WHERE id = 1 AND leader_id = ?
-                ",
-                params![now_ts, now_ts, worker_id],
-            )
-            .map_err(map_db_error)?;
-
+        let updated = release_embedding_leader_in_tx(&conn, &worker_id).map_err(map_db_error)?;
         conn.execute_batch("COMMIT").map_err(map_db_error)?;
-        Ok(updated == 1)
+        Ok(updated)
     }
 
     fn complete_embedding_job(&self, message_id: String, model: String) -> PyResult<()> {
@@ -2777,6 +2813,38 @@ impl CoreDb {
     }
 }
 
+impl CoreDb {
+    fn ensure_embedding_leader_self(
+        &self,
+        conn: &Connection,
+        leader_ttl_seconds: i64,
+        leader_heartbeat_seconds: i64,
+    ) -> PyResult<bool> {
+        let now_ts = now();
+        let can_skip = leader_heartbeat_seconds < leader_ttl_seconds;
+        let mut last_heartbeat = self
+            .leader_last_heartbeat
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("leader heartbeat lock poisoned"))?;
+        let should_update = match *last_heartbeat {
+            Some(last) if can_skip && (now_ts - last) < leader_heartbeat_seconds as f64 => false,
+            _ => true,
+        };
+        if !should_update {
+            return Ok(true);
+        }
+
+        let updated = claim_embedding_leader_in_tx(conn, &self.leader_id, leader_ttl_seconds)
+            .map_err(map_db_error)?;
+        if updated {
+            *last_heartbeat = Some(now_ts);
+            return Ok(true);
+        }
+        *last_heartbeat = None;
+        Ok(false)
+    }
+}
+
 fn now() -> f64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2790,6 +2858,204 @@ fn new_reclaim_token() -> String {
 
 fn new_id() -> String {
     Uuid::new_v4().simple().to_string()[0..10].to_string()
+}
+
+fn embedding_jobs_claimable_where_clause() -> &'static str {
+    "
+    model = ?
+    AND attempts < ?
+    AND (
+      status = 'pending'
+      OR (status = 'error' AND updated_at <= ?)
+      OR (status = 'processing' AND (locked_at IS NULL OR locked_at <= ?))
+    )
+    "
+}
+
+fn has_ready_embedding_jobs_in_tx(
+    conn: &Connection,
+    model: &str,
+    limit: usize,
+    lock_ttl_seconds: i64,
+    error_retry_seconds: i64,
+    max_attempts: i64,
+) -> rusqlite::Result<bool> {
+    let now_ts = now();
+    let stale_before = now_ts - lock_ttl_seconds as f64;
+    let error_ready_before = now_ts - error_retry_seconds as f64;
+    let sql = format!(
+        "
+        SELECT 1
+        FROM embedding_jobs
+        WHERE {}
+        LIMIT ?
+        ",
+        embedding_jobs_claimable_where_clause()
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let found = stmt
+        .query_row(
+            params![
+                model,
+                max_attempts,
+                error_ready_before,
+                stale_before,
+                limit as i64
+            ],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    Ok(found.is_some())
+}
+
+fn claim_embedding_jobs_in_tx(
+    conn: &Connection,
+    model: &str,
+    limit: usize,
+    worker_id: &str,
+    lock_ttl_seconds: i64,
+    error_retry_seconds: i64,
+    max_attempts: i64,
+) -> rusqlite::Result<Vec<(String, String, i64)>> {
+    let claimed_at = now();
+    let stale_before = claimed_at - lock_ttl_seconds as f64;
+    let error_ready_before = claimed_at - error_retry_seconds as f64;
+
+    let select_sql = format!(
+        "
+        SELECT message_id, topic_id
+        FROM embedding_jobs
+        WHERE {}
+        ORDER BY updated_at ASC
+        LIMIT ?
+        ",
+        embedding_jobs_claimable_where_clause()
+    );
+    let mut stmt = conn.prepare(&select_sql)?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map(
+            params![
+                model,
+                max_attempts,
+                error_ready_before,
+                stale_before,
+                limit as i64
+            ],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let message_ids: Vec<String> = rows
+        .iter()
+        .map(|(message_id, _)| message_id.clone())
+        .collect();
+    let placeholders = placeholders(message_ids.len());
+    let mut params_vec: Vec<Value> = vec![
+        Value::from(worker_id.to_string()),
+        Value::from(claimed_at),
+        Value::from(claimed_at),
+        Value::from(model.to_string()),
+        Value::from(max_attempts),
+        Value::from(error_ready_before),
+        Value::from(stale_before),
+    ];
+    for message_id in &message_ids {
+        params_vec.push(Value::from(message_id.clone()));
+    }
+
+    let update_sql = format!(
+        "
+        UPDATE embedding_jobs
+        SET
+          status = 'processing',
+          locked_by = ?,
+          locked_at = ?,
+          updated_at = ?,
+          attempts = attempts + 1
+        WHERE {}
+          AND message_id IN ({})
+        ",
+        embedding_jobs_claimable_where_clause(),
+        placeholders
+    );
+    conn.execute(&update_sql, params_from_iter(params_vec.iter()))?;
+
+    let mut stmt = conn.prepare(
+        "
+        SELECT message_id, topic_id, attempts
+        FROM embedding_jobs
+        WHERE model = ? AND locked_by = ? AND locked_at = ?
+        ",
+    )?;
+    let claimed_rows = stmt
+        .query_map(params![model, worker_id, claimed_at], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(claimed_rows)
+}
+
+fn claim_embedding_leader_in_tx(
+    conn: &Connection,
+    worker_id: &str,
+    ttl_seconds: i64,
+) -> rusqlite::Result<bool> {
+    conn.execute(
+        "
+        INSERT OR IGNORE INTO embedding_worker_leader(id, leader_id, heartbeat_at, expires_at)
+        VALUES (1, '', 0, 0)
+        ",
+        [],
+    )?;
+
+    let now_ts = now();
+    let expires_at = now_ts + ttl_seconds as f64;
+    let updated = conn.execute(
+        "
+        UPDATE embedding_worker_leader
+        SET leader_id = ?, heartbeat_at = ?, expires_at = ?
+        WHERE id = 1 AND (leader_id = ? OR expires_at <= ?)
+        ",
+        params![worker_id, now_ts, expires_at, worker_id, now_ts],
+    )?;
+    Ok(updated == 1)
+}
+
+fn release_embedding_leader_in_tx(conn: &Connection, worker_id: &str) -> rusqlite::Result<bool> {
+    let now_ts = now();
+    let updated = conn.execute(
+        "
+        UPDATE embedding_worker_leader
+        SET leader_id = '', heartbeat_at = ?, expires_at = ?
+        WHERE id = 1 AND leader_id = ?
+        ",
+        params![now_ts, now_ts, worker_id],
+    )?;
+    Ok(updated == 1)
+}
+
+fn claimed_rows_to_py(
+    py: Python<'_>,
+    claimed_rows: Vec<(String, String, i64)>,
+) -> PyResult<Py<PyAny>> {
+    let out = PyList::empty(py);
+    for (message_id, topic_id, attempts) in claimed_rows {
+        let dict = PyDict::new(py);
+        dict.set_item("message_id", message_id)?;
+        dict.set_item("topic_id", topic_id)?;
+        dict.set_item("attempts", attempts)?;
+        out.append(dict)?;
+    }
+    Ok(out.into())
 }
 
 fn bump_topics_version(tx: &rusqlite::Transaction<'_>) -> rusqlite::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -945,7 +945,7 @@ impl CoreDb {
             }
 
             conn.execute_batch("COMMIT").map_err(map_db_error)?;
-            Ok(claimed_rows_to_py(py, claimed_rows)?)
+            claimed_rows_to_py(py, claimed_rows)
         })();
 
         if result.is_err() {
@@ -2826,10 +2826,10 @@ impl CoreDb {
             .leader_last_heartbeat
             .lock()
             .map_err(|_| PyRuntimeError::new_err("leader heartbeat lock poisoned"))?;
-        let should_update = match *last_heartbeat {
-            Some(last) if can_skip && (now_ts - last) < leader_heartbeat_seconds as f64 => false,
-            _ => true,
-        };
+        let should_update = !matches!(
+            *last_heartbeat,
+            Some(last) if can_skip && (now_ts - last) < leader_heartbeat_seconds as f64
+        );
         if !should_update {
             return Ok(true);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,7 @@ fn embed_texts(
 struct CoreDb {
     path: String,
     fts_available: Mutex<Option<bool>>,
+    schema_initialized: Mutex<bool>,
     leader_id: String,
     leader_last_heartbeat: Mutex<Option<f64>>,
 }
@@ -420,6 +421,7 @@ impl CoreDb {
         Ok(Self {
             path: resolved,
             fts_available: Mutex::new(None),
+            schema_initialized: Mutex::new(false),
             leader_id: new_id(),
             leader_last_heartbeat: Mutex::new(None),
         })
@@ -2511,7 +2513,14 @@ impl CoreDb {
             .map_err(map_db_error)?;
         conn.busy_timeout(Duration::from_millis(2000))
             .map_err(map_db_error)?;
-        self.ensure_schema(&conn)?;
+        let mut schema_initialized = self
+            .schema_initialized
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("schema initialization lock poisoned"))?;
+        if !*schema_initialized {
+            self.ensure_schema(&conn)?;
+            *schema_initialized = true;
+        }
         Ok(conn)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -937,6 +937,9 @@ impl CoreDb {
 
             if claimed_rows.is_empty() {
                 release_embedding_leader_in_tx(&conn, &self.leader_id).map_err(map_db_error)?;
+                // The DB row is authoritative once the transaction succeeds; cache resets are
+                // best-effort so a poisoned local mutex does not turn a committed lease update
+                // into a false failure.
                 if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
                     *last_heartbeat = None;
                 }
@@ -969,6 +972,8 @@ impl CoreDb {
             let updated = claim_embedding_leader_in_tx(&conn, &self.leader_id, ttl_seconds)
                 .map_err(map_db_error)?;
             conn.execute_batch("COMMIT").map_err(map_db_error)?;
+            // This heartbeat is only a process-local skip cache; once the DB write commits,
+            // cache maintenance should not be able to fail the renewal path.
             if updated {
                 if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
                     *last_heartbeat = Some(now());
@@ -996,6 +1001,8 @@ impl CoreDb {
             let updated =
                 release_embedding_leader_in_tx(&conn, &self.leader_id).map_err(map_db_error)?;
             conn.execute_batch("COMMIT").map_err(map_db_error)?;
+            // The lease release is already committed in SQLite; clearing the local cache is
+            // best-effort bookkeeping only.
             if let Ok(mut last_heartbeat) = self.leader_last_heartbeat.lock() {
                 *last_heartbeat = None;
             }

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -213,6 +213,65 @@ def test_embedding_leader_lock_is_exclusive(tmp_path):
     assert db2.claim_embedding_leader(worker_id="worker-b", ttl_seconds=30) is True
 
 
+def test_embedding_jobs_if_leader_handoff_releases_self_lease(tmp_path):
+    db_path = tmp_path / "bus.sqlite"
+    db1 = AgentBusDB(path=str(db_path))
+    db2 = AgentBusDB(path=str(db_path))
+    topic = db1.topic_create(name="pink", metadata=None, mode="new")
+
+    sent, _, _, _ = db1.sync_once(
+        topic_id=topic.topic_id,
+        agent_name="a",
+        outbox=[{"content_markdown": "hello", "message_type": "message"}],
+        max_items=10,
+        include_self=True,
+        auto_advance=True,
+        ack_through=None,
+    )
+    message_id = sent[0][0].message_id
+    model = "unit-test-model"
+    db1.enqueue_embedding_jobs(jobs=[(message_id, topic.topic_id)], model=model)
+
+    assert (
+        db1.has_ready_embedding_jobs(
+            model=model,
+            limit=10,
+            lock_ttl_seconds=300,
+            error_retry_seconds=0,
+            max_attempts=3,
+        )
+        is True
+    )
+
+    claimed = db1.claim_embedding_jobs_if_leader(
+        model=model,
+        limit=10,
+        lock_ttl_seconds=300,
+        error_retry_seconds=0,
+        max_attempts=3,
+        leader_ttl_seconds=30,
+        leader_heartbeat_seconds=10,
+    )
+    assert [c["message_id"] for c in claimed] == [message_id]
+    assert db1.renew_embedding_leader_self(ttl_seconds=30) is True
+
+    db1.complete_embedding_job(message_id=message_id, model=model)
+
+    assert (
+        db1.has_ready_embedding_jobs(
+            model=model,
+            limit=10,
+            lock_ttl_seconds=300,
+            error_retry_seconds=0,
+            max_attempts=3,
+        )
+        is False
+    )
+    assert db2.claim_embedding_leader(worker_id="worker-b", ttl_seconds=30) is False
+    assert db1.release_embedding_leader_self() is True
+    assert db2.claim_embedding_leader(worker_id="worker-b", ttl_seconds=30) is True
+
+
 def test_reserve_agent_name_requires_reclaim_token_and_does_not_mark_presence(tmp_path):
     db = AgentBusDB(path=str(tmp_path / "bus.sqlite"))
     topic = db.topic_create(name="pink", metadata=None, mode="new")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -272,6 +272,40 @@ def test_embedding_jobs_if_leader_handoff_releases_self_lease(tmp_path):
     assert db2.claim_embedding_leader(worker_id="worker-b", ttl_seconds=30) is True
 
 
+def test_has_ready_embedding_jobs_does_not_rewrite_schema_after_init(tmp_path):
+    db = AgentBusDB(path=str(tmp_path / "bus.sqlite"))
+
+    assert (
+        db.has_ready_embedding_jobs(
+            model="unit-test-model",
+            limit=10,
+            lock_ttl_seconds=300,
+            error_retry_seconds=0,
+            max_attempts=3,
+        )
+        is False
+    )
+
+    with sqlite3.connect(db.path) as conn:
+        schema_version_before = conn.execute("PRAGMA schema_version").fetchone()[0]
+
+    assert (
+        db.has_ready_embedding_jobs(
+            model="unit-test-model",
+            limit=10,
+            lock_ttl_seconds=300,
+            error_retry_seconds=0,
+            max_attempts=3,
+        )
+        is False
+    )
+
+    with sqlite3.connect(db.path) as conn:
+        schema_version_after = conn.execute("PRAGMA schema_version").fetchone()[0]
+
+    assert schema_version_after == schema_version_before
+
+
 def test_reserve_agent_name_requires_reclaim_token_and_does_not_mark_presence(tmp_path):
     db = AgentBusDB(path=str(tmp_path / "bus.sqlite"))
     topic = db.topic_create(name="pink", metadata=None, mode="new")

--- a/tests/test_embedding_worker.py
+++ b/tests/test_embedding_worker.py
@@ -14,9 +14,11 @@ class _WorkerDB:
         *,
         ready_sequence: list[bool],
         claim_sequence: list[list[dict[str, object]]] | None = None,
+        expected_limit: int = 1,
     ) -> None:
         self.ready_sequence = list(ready_sequence)
         self.claim_sequence = list(claim_sequence or [])
+        self.expected_limit = expected_limit
         self.peek_calls = 0
         self.claim_calls = 0
         self.renew_calls = 0
@@ -35,7 +37,7 @@ class _WorkerDB:
         max_attempts: int,
     ) -> bool:
         assert model == "unit-test-model"
-        assert limit == 1
+        assert limit == self.expected_limit
         assert lock_ttl_seconds > 0
         assert error_retry_seconds >= 0
         assert max_attempts > 0
@@ -56,7 +58,7 @@ class _WorkerDB:
         leader_heartbeat_seconds: int,
     ) -> list[dict[str, object]]:
         assert model == "unit-test-model"
-        assert limit == 1
+        assert limit == self.expected_limit
         assert lock_ttl_seconds > 0
         assert error_retry_seconds >= 0
         assert max_attempts > 0
@@ -178,6 +180,7 @@ def test_worker_renews_self_lease_while_processing_and_releases_when_drained(
                 {"message_id": "msg-2", "topic_id": "topic-1", "attempts": 1},
             ]
         ],
+        expected_limit=2,
     )
     stop_event = _StopAfterWaits(stop_after=2)
     monkeypatch.setattr(
@@ -195,7 +198,7 @@ def test_worker_renews_self_lease_while_processing_and_releases_when_drained(
         model="unit-test-model",
         chunk_size=100,
         chunk_overlap=0,
-        batch_size=1,
+        batch_size=2,
         lock_ttl_seconds=30,
         error_retry_seconds=0,
         max_attempts=3,
@@ -211,6 +214,29 @@ def test_worker_renews_self_lease_while_processing_and_releases_when_drained(
     assert db.release_calls == 1
     assert db.completed == ["msg-1", "msg-2"]
     assert db.failed == []
+
+
+def test_worker_idle_backoff_never_drops_below_configured_poll_interval() -> None:
+    db = _WorkerDB(ready_sequence=[False, False])
+    stop_event = _StopAfterWaits(stop_after=2)
+
+    _worker_loop(
+        db=db,
+        worker_id="worker-1",
+        model="unit-test-model",
+        chunk_size=100,
+        chunk_overlap=0,
+        batch_size=1,
+        lock_ttl_seconds=30,
+        error_retry_seconds=0,
+        max_attempts=3,
+        poll_seconds=5.0,
+        leader_ttl_seconds=30,
+        leader_heartbeat_seconds=10,
+        stop_event=stop_event,  # type: ignore[arg-type]
+    )
+
+    assert stop_event.waits == [5.0, 5.0]
 
 
 def test_worker_does_not_release_again_when_claim_returns_empty(

--- a/tests/test_embedding_worker.py
+++ b/tests/test_embedding_worker.py
@@ -1,66 +1,149 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from agent_bus import _core
 from agent_bus.embedding_worker import _worker_loop
 
 
-class _IdleWorkerDB:
-    def __init__(self) -> None:
-        self.owner: str | None = None
-        self.idle_release_seen = False
+class _WorkerDB:
+    def __init__(
+        self,
+        *,
+        ready_sequence: list[bool],
+        claim_sequence: list[list[dict[str, object]]] | None = None,
+    ) -> None:
+        self.ready_sequence = list(ready_sequence)
+        self.claim_sequence = list(claim_sequence or [])
+        self.peek_calls = 0
+        self.claim_calls = 0
+        self.renew_calls = 0
+        self.release_calls = 0
+        self.completed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+        self.upserted: list[str] = []
 
-    def claim_embedding_leader(self, worker_id: str, ttl_seconds: int) -> bool:
-        assert ttl_seconds > 0
-        if self.owner in (None, worker_id):
-            self.owner = worker_id
-            return True
-        return False
-
-    def release_embedding_leader(self, worker_id: str) -> bool:
-        if self.owner == worker_id:
-            self.owner = None
-            return True
-        return False
-
-    def claim_embedding_jobs(
+    def has_ready_embedding_jobs(
         self,
         *,
         model: str,
         limit: int,
-        worker_id: str,
         lock_ttl_seconds: int,
         error_retry_seconds: int,
         max_attempts: int,
-    ) -> list[dict[str, object]]:
+    ) -> bool:
         assert model == "unit-test-model"
         assert limit == 1
-        assert worker_id == "worker-1"
         assert lock_ttl_seconds > 0
         assert error_retry_seconds >= 0
         assert max_attempts > 0
-        return []
+        self.peek_calls += 1
+        if not self.ready_sequence:
+            return False
+        return self.ready_sequence.pop(0)
+
+    def claim_embedding_jobs_if_leader(
+        self,
+        *,
+        model: str,
+        limit: int,
+        lock_ttl_seconds: int,
+        error_retry_seconds: int,
+        max_attempts: int,
+        leader_ttl_seconds: int,
+        leader_heartbeat_seconds: int,
+    ) -> list[dict[str, object]]:
+        assert model == "unit-test-model"
+        assert limit == 1
+        assert lock_ttl_seconds > 0
+        assert error_retry_seconds >= 0
+        assert max_attempts > 0
+        assert leader_ttl_seconds > 0
+        assert leader_heartbeat_seconds > 0
+        self.claim_calls += 1
+        if not self.claim_sequence:
+            return []
+        return self.claim_sequence.pop(0)
+
+    def renew_embedding_leader_self(self, *, ttl_seconds: int) -> bool:
+        assert ttl_seconds > 0
+        self.renew_calls += 1
+        return True
+
+    def release_embedding_leader_self(self) -> bool:
+        self.release_calls += 1
+        return True
+
+    def get_message_by_id(self, *, message_id: str) -> SimpleNamespace:
+        return SimpleNamespace(content_markdown=f"content {message_id}")
+
+    def get_embedding_state(self, *, message_id: str, model: str) -> None:
+        assert model == "unit-test-model"
+        return None
+
+    def upsert_embeddings(
+        self,
+        *,
+        message_id: str,
+        model: str,
+        topic_id: str,
+        content_hash: str,
+        chunk_size: int,
+        chunk_overlap: int,
+        dims: int,
+        chunks: list[dict[str, object]],
+    ) -> None:
+        self.upserted.append(message_id)
+        assert model == "unit-test-model"
+        assert topic_id == "topic-1"
+        assert content_hash
+        assert chunk_size > 0
+        assert chunk_overlap >= 0
+        assert dims >= 0
+        assert isinstance(chunks, list)
+
+    def complete_embedding_job(self, *, message_id: str, model: str) -> None:
+        assert model == "unit-test-model"
+        self.completed.append(message_id)
+
+    def fail_embedding_job(self, *, message_id: str, model: str, error: str) -> None:
+        assert model == "unit-test-model"
+        self.failed.append((message_id, error))
 
 
-class _StopAfterIdleWait:
-    def __init__(self, db: _IdleWorkerDB) -> None:
-        self._db = db
+class _StopAfterWaits:
+    def __init__(self, stop_after: int) -> None:
+        assert stop_after > 0
+        self._stop_after = stop_after
         self._set = False
+        self.waits: list[float] = []
 
     def is_set(self) -> bool:
         return self._set
 
     def wait(self, timeout: float) -> bool:
         assert timeout >= 0
-        self._db.idle_release_seen = self._db.owner is None
-        self._set = True
+        self.waits.append(timeout)
+        if len(self.waits) >= self._stop_after:
+            self._set = True
         return True
 
 
-def test_idle_worker_releases_leader_before_sleeping() -> None:
-    db = _IdleWorkerDB()
-    stop_event = _StopAfterIdleWait(db)
+class _Monotonic:
+    def __init__(self, values: list[float]) -> None:
+        self._values = list(values)
+
+    def __call__(self) -> float:
+        if self._values:
+            return self._values.pop(0)
+        return 10.0
+
+
+def test_idle_worker_peeks_read_only_without_releasing_when_it_has_no_lease() -> None:
+    db = _WorkerDB(ready_sequence=[False])
+    stop_event = _StopAfterWaits(stop_after=1)
 
     _worker_loop(
         db=db,
@@ -78,7 +161,91 @@ def test_idle_worker_releases_leader_before_sleeping() -> None:
         stop_event=stop_event,  # type: ignore[arg-type]
     )
 
-    assert db.idle_release_seen is True
+    assert db.peek_calls == 1
+    assert db.claim_calls == 0
+    assert db.renew_calls == 0
+    assert db.release_calls == 0
+
+
+def test_worker_renews_self_lease_while_processing_and_releases_when_drained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _WorkerDB(
+        ready_sequence=[True, False],
+        claim_sequence=[
+            [
+                {"message_id": "msg-1", "topic_id": "topic-1", "attempts": 1},
+                {"message_id": "msg-2", "topic_id": "topic-1", "attempts": 1},
+            ]
+        ],
+    )
+    stop_event = _StopAfterWaits(stop_after=2)
+    monkeypatch.setattr(
+        "agent_bus.embedding_worker.time.monotonic",
+        _Monotonic([0.0, 0.1, 1.1, 1.2, 1.3]),
+    )
+    monkeypatch.setattr(
+        "agent_bus.embedding_worker._index_message",
+        lambda **_: "indexed",
+    )
+
+    _worker_loop(
+        db=db,
+        worker_id="worker-1",
+        model="unit-test-model",
+        chunk_size=100,
+        chunk_overlap=0,
+        batch_size=1,
+        lock_ttl_seconds=30,
+        error_retry_seconds=0,
+        max_attempts=3,
+        poll_seconds=0.01,
+        leader_ttl_seconds=30,
+        leader_heartbeat_seconds=1,
+        stop_event=stop_event,  # type: ignore[arg-type]
+    )
+
+    assert db.peek_calls == 2
+    assert db.claim_calls == 1
+    assert db.renew_calls >= 1
+    assert db.release_calls == 1
+    assert db.completed == ["msg-1", "msg-2"]
+    assert db.failed == []
+
+
+def test_worker_does_not_release_again_when_claim_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _WorkerDB(
+        ready_sequence=[True, False],
+        claim_sequence=[[]],
+    )
+    stop_event = _StopAfterWaits(stop_after=2)
+    monkeypatch.setattr(
+        "agent_bus.embedding_worker.time.monotonic",
+        _Monotonic([0.0, 0.1, 1.1]),
+    )
+
+    _worker_loop(
+        db=db,
+        worker_id="worker-1",
+        model="unit-test-model",
+        chunk_size=100,
+        chunk_overlap=0,
+        batch_size=1,
+        lock_ttl_seconds=30,
+        error_retry_seconds=0,
+        max_attempts=3,
+        poll_seconds=0.01,
+        leader_ttl_seconds=30,
+        leader_heartbeat_seconds=1,
+        stop_event=stop_event,  # type: ignore[arg-type]
+    )
+
+    assert db.peek_calls == 2
+    assert db.claim_calls == 1
+    assert db.renew_calls == 0
+    assert db.release_calls == 0
 
 
 def test_embedding_core_rejects_e5_small_v2_alias() -> None:

--- a/tests/test_embedding_worker.py
+++ b/tests/test_embedding_worker.py
@@ -149,7 +149,6 @@ def test_idle_worker_peeks_read_only_without_releasing_when_it_has_no_lease() ->
 
     _worker_loop(
         db=db,
-        worker_id="worker-1",
         model="unit-test-model",
         chunk_size=100,
         chunk_overlap=0,
@@ -194,7 +193,6 @@ def test_worker_renews_self_lease_while_processing_and_releases_when_drained(
 
     _worker_loop(
         db=db,
-        worker_id="worker-1",
         model="unit-test-model",
         chunk_size=100,
         chunk_overlap=0,
@@ -222,7 +220,6 @@ def test_worker_idle_backoff_never_drops_below_configured_poll_interval() -> Non
 
     _worker_loop(
         db=db,
-        worker_id="worker-1",
         model="unit-test-model",
         chunk_size=100,
         chunk_overlap=0,
@@ -254,7 +251,6 @@ def test_worker_does_not_release_again_when_claim_returns_empty(
 
     _worker_loop(
         db=db,
-        worker_id="worker-1",
         model="unit-test-model",
         chunk_size=100,
         chunk_overlap=0,

--- a/tests/test_embedding_worker.py
+++ b/tests/test_embedding_worker.py
@@ -67,7 +67,9 @@ class _WorkerDB:
         self.claim_calls += 1
         if not self.claim_sequence:
             return []
-        return self.claim_sequence.pop(0)
+        batch = self.claim_sequence.pop(0)
+        assert len(batch) <= limit
+        return batch
 
     def renew_embedding_leader_self(self, *, ttl_seconds: int) -> bool:
         assert ttl_seconds > 0


### PR DESCRIPTION
## Summary
- add a read-only embedding-job readiness probe plus self-scoped claim, renew, and release helpers in the Rust core
- update the background embedding worker to avoid idle write churn, hold the self lease only while active, and back off cleanly when the queue drains
- add regression coverage for idle polls, lease handoff, lease renewal, and empty-claim races

## Testing
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest`

Closes #24
Closes #9