### PR TITLE
release: prepare 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] - Unreleased
+## [0.4.1] - Unreleased
+
+### Fixed
+
+- The background embedding worker now uses a read-only readiness probe while idle and only enters
+  the Rust-side write transaction when embedding work is actually pending, which removes the
+  repeated idle SQLite writer churn that could cascade into `fseventsd` spikes on macOS.
+- Lease claiming and job claiming now stay coordinated inside the Rust core, while idle workers
+  release their self-held lease promptly so `agent-bus cli embeddings index` can still take the
+  exclusive path without getting blocked behind a sticky idle background worker.
+- Repeated embedding readiness probes no longer rewrite SQLite schema objects on every connect.
+  The DB now initializes schema once per `CoreDb` instance so the supposedly read-only peek path
+  stays low-churn in practice as well as in design.
+
+### Upgrade
+
+- If you run long-lived background workers together with manual `agent-bus cli embeddings index`
+  runs, upgrade to `0.4.1` to pick up the lease handoff and idle-churn fixes.
+- To preview this release explicitly with `uvx`, run:
+
+  ```bash
+  uvx --from agent-bus-mcp==0.4.1 agent-bus --help
+  ```
+
+## [0.4.0]
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-bus-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fastembed",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bus-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-bus-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Local SQLite-backed MCP bus for peer coding agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/spec.md
+++ b/spec.md
@@ -176,7 +176,7 @@ Constraints:
 
 - `ok: true`
 - `spec_version: string`
-- `package_version: string` (installed package/runtime version, for example `0.4.0`)
+- `package_version: string` (installed package/runtime version, for example `0.4.1`)
 
 ### 4.3 `sync()` semantics
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agent-bus-mcp"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump the Python package and Rust crate version to 0.4.1
- add a 0.4.1 changelog entry for the embedding lease and idle SQLite churn fixes merged in #25
- switch the PyPI/TestPyPI publish workflow from API-token secrets to GitHub trusted publishing via OIDC
- refresh the lockfiles and spec example so the release metadata stays consistent

## Workflow notes
- `publish-testpypi.yml` now requires matching trusted publisher entries on both PyPI and TestPyPI
- the upload job uses the GitHub environment name that matches `publish_target` (`testpypi` or `pypi`)
- the upload job now requires `id-token: write` and no longer reads `TEST_PYPI_API_TOKEN` / `PYPI_API_TOKEN` secrets

## Testing
- `uv run maturin develop`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-testpypi.yml")'`
- validated the trusted-publishing upload shell path with `bash -n`
