### PR TITLE
ci: use trusted publishing and update Node 24 actions

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           enable-cache: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 
@@ -89,7 +89,7 @@ jobs:
         with:
           enable-cache: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -12,8 +12,7 @@ on:
           - testpypi
           - pypi
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   pypi-readme:
@@ -36,6 +35,8 @@ jobs:
   build:
     needs: pypi-readme
     uses: ./.github/workflows/build-wheels.yml
+    permissions:
+      contents: read
     with:
       upload_artifacts: true
       use_pypi_readme: true
@@ -44,6 +45,12 @@ jobs:
   upload:
     needs: build
     runs-on: ubuntu-latest
+    # Configure matching trusted publishers on PyPI and TestPyPI for this
+    # workflow path and the corresponding GitHub environment name.
+    environment: ${{ inputs.publish_target }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -66,24 +73,21 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Upload to TestPyPI
+      - name: Upload distributions with trusted publishing
         shell: bash
         run: |
           set -euo pipefail
           publish_url="https://test.pypi.org/legacy/"
           check_url="https://test.pypi.org/simple/"
-          token="${{ secrets.TEST_PYPI_API_TOKEN }}"
           if [ "${{ inputs.publish_target }}" = "pypi" ]; then
             publish_url="https://upload.pypi.org/legacy/"
             check_url="https://pypi.org/simple/"
-            token="${{ secrets.PYPI_API_TOKEN }}"
           fi
-          UV_PUBLISH_TOKEN="$token" \
-            uv publish \
-              --publish-url "$publish_url" \
-              --check-url "$check_url" \
-              --trusted-publishing never \
-              dist/*
+          uv publish \
+            --publish-url "$publish_url" \
+            --check-url "$check_url" \
+            --trusted-publishing always \
+            dist/*
 
       - name: Determine version
         id: version
@@ -147,6 +151,8 @@ jobs:
     needs: upload
     if: ${{ inputs.publish_target == 'pypi' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary
- replace TestPyPI and PyPI API-token publishing with GitHub OIDC trusted publishing
- scope workflow permissions so only the upload job gets `id-token: write` and only the tag job gets `contents: write`
- bind the upload job to the `pypi` / `testpypi` GitHub environments so the trusted-publisher identity is explicit
- upgrade `pnpm/action-setup` from `v4` to `v5` in CI and wheel builds so the repo no longer depends on the Node 20 action runtime flagged in issue #27

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/build-wheels.yml"); YAML.load_file(".github/workflows/publish-testpypi.yml")'`
- `git diff --check`

## Follow-up
- configure matching trusted publishers on PyPI and TestPyPI for `.github/workflows/publish-testpypi.yml`
- remove the old `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets once the new flow is verified
- after merge, test a `publish_target=testpypi` run before using the `pypi` path
