### PR TITLE
test(frontend): scope workbench e2e thread assertion

### DIFF
--- a/frontend/tests/workbench.spec.ts
+++ b/frontend/tests/workbench.spec.ts
@@ -13,5 +13,5 @@ test("opens topics in tabs and navigates from sidebar search", async ({ page }) 
   await result.click()
 
   await expect(page).toHaveURL(/\/topics\/.+\?focus=/)
-  await expect(page.getByText("beta handoff summary")).toBeVisible()
+  await expect(page.locator("main").getByText("beta handoff summary")).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- fix the Playwright workbench smoke test to assert inside the main thread pane instead of against the whole page
- avoid strict-mode selector failures when the same message summary text appears in both the sidebar preview and the opened thread body

## Why
- PR #29's frontend job failed because the previous assertion matched both the sidebar result preview and the thread message body after navigation

## How to test
- `pnpm --dir frontend exec playwright test tests/workbench.spec.ts`
