### PR TITLE
ci: support TestPyPI dev version suffixes

### DIFF
--- a/.github/scripts/apply_version_overrides.py
+++ b/.github/scripts/apply_version_overrides.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 def replace_version(path: Path, current: str, updated: str) -> None:
     text = path.read_text(encoding="utf-8")
-    new_text = text.replace(f'version = "{current}"', f'version = "{updated}"', 1)
+    current_version_field = f'version = "{current}"'
+    if current_version_field not in text:
+        raise SystemExit(f"Failed to update version in {path}")
+    if current == updated:
+        return
+    new_text = text.replace(current_version_field, f'version = "{updated}"', 1)
     if new_text == text:
         raise SystemExit(f"Failed to update version in {path}")
     path.write_text(new_text, encoding="utf-8")

--- a/.github/scripts/apply_version_overrides.py
+++ b/.github/scripts/apply_version_overrides.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+
+def replace_version(path: Path, current: str, updated: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    new_text = text.replace(f'version = "{current}"', f'version = "{updated}"', 1)
+    if new_text == text:
+        raise SystemExit(f"Failed to update version in {path}")
+    path.write_text(new_text, encoding="utf-8")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: apply_version_overrides.py <python-version> <cargo-version>")
+
+    py_version = sys.argv[1].strip()
+    cargo_version = sys.argv[2].strip()
+    if not py_version or not cargo_version:
+        raise SystemExit("expected both python and cargo version overrides")
+
+    pyproject_path = Path("pyproject.toml")
+    cargo_path = Path("Cargo.toml")
+
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    cargo = tomllib.loads(cargo_path.read_text(encoding="utf-8"))
+
+    current_py_version = pyproject["project"]["version"]
+    current_cargo_version = cargo["package"]["version"]
+
+    replace_version(pyproject_path, current_py_version, py_version)
+    replace_version(cargo_path, current_cargo_version, cargo_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,6 +12,12 @@ on:
       pypi_readme_artifact_name:
         type: string
         default: pypi-readme
+      version_override_python:
+        type: string
+        default: ""
+      version_override_cargo:
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       upload_artifacts:
@@ -23,6 +29,12 @@ on:
       pypi_readme_artifact_name:
         type: string
         default: pypi-readme
+      version_override_python:
+        type: string
+        default: ""
+      version_override_cargo:
+        type: string
+        default: ""
 
 env:
   ORT_VERSION: "1.23.2"
@@ -33,6 +45,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+
+      - name: Apply workflow version overrides
+        if: inputs.version_override_python != '' || inputs.version_override_cargo != ''
+        shell: bash
+        env:
+          PY_VERSION: ${{ inputs.version_override_python }}
+          CARGO_VERSION: ${{ inputs.version_override_cargo }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          py_version = os.environ["PY_VERSION"].strip()
+          cargo_version = os.environ["CARGO_VERSION"].strip()
+          if not py_version or not cargo_version:
+            raise SystemExit("Expected both version overrides to be set together")
+
+          pyproject_path = Path("pyproject.toml")
+          pyproject_text = pyproject_path.read_text(encoding="utf-8")
+          current_py_version = tomllib.loads(pyproject_text)["project"]["version"]
+          updated_pyproject = pyproject_text.replace(
+            f'version = "{current_py_version}"',
+            f'version = "{py_version}"',
+            1,
+          )
+          if updated_pyproject == pyproject_text:
+            raise SystemExit("Failed to update pyproject.toml version")
+          pyproject_path.write_text(updated_pyproject, encoding="utf-8")
+
+          cargo_path = Path("Cargo.toml")
+          cargo_text = cargo_path.read_text(encoding="utf-8")
+          current_cargo_version = tomllib.loads(cargo_text)["package"]["version"]
+          updated_cargo = cargo_text.replace(
+            f'version = "{current_cargo_version}"',
+            f'version = "{cargo_version}"',
+            1,
+          )
+          if updated_cargo == cargo_text:
+            raise SystemExit("Failed to update Cargo.toml version")
+          cargo_path.write_text(updated_cargo, encoding="utf-8")
+          PY
 
       - uses: pnpm/action-setup@v5
         with:
@@ -66,9 +121,13 @@ jobs:
           path.write_text(updated, encoding="utf-8")
           PY
 
-      - name: Validate version sync
+      - name: Validate version configuration
+        env:
+          EXPECTED_PY_VERSION: ${{ inputs.version_override_python }}
+          EXPECTED_CARGO_VERSION: ${{ inputs.version_override_cargo }}
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
+          import os
           import tomllib
 
           with open("pyproject.toml", "rb") as fh:
@@ -79,11 +138,27 @@ jobs:
           py_version = pyproject["project"]["version"]
           cargo_version = cargo["package"]["version"]
 
-          if py_version != cargo_version:
-            raise SystemExit(
-              f"Version mismatch: pyproject.toml={py_version} Cargo.toml={cargo_version}"
-            )
-          print(f"Version OK: {py_version}")
+          expected_py = os.environ["EXPECTED_PY_VERSION"].strip()
+          expected_cargo = os.environ["EXPECTED_CARGO_VERSION"].strip()
+
+          if expected_py or expected_cargo:
+            if not expected_py or not expected_cargo:
+              raise SystemExit("Expected both version overrides to be provided together")
+            if py_version != expected_py:
+              raise SystemExit(
+                f"pyproject.toml version mismatch: expected {expected_py}, got {py_version}"
+              )
+            if cargo_version != expected_cargo:
+              raise SystemExit(
+                f"Cargo.toml version mismatch: expected {expected_cargo}, got {cargo_version}"
+              )
+            print(f"Version overrides OK: pyproject.toml={py_version} Cargo.toml={cargo_version}")
+          else:
+            if py_version != cargo_version:
+              raise SystemExit(
+                f"Version mismatch: pyproject.toml={py_version} Cargo.toml={cargo_version}"
+              )
+            print(f"Version OK: {py_version}")
           PY
 
       - name: Install frontend dependencies
@@ -117,6 +192,49 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v5
+
+      - name: Apply workflow version overrides
+        if: inputs.version_override_python != '' || inputs.version_override_cargo != ''
+        shell: bash
+        env:
+          PY_VERSION: ${{ inputs.version_override_python }}
+          CARGO_VERSION: ${{ inputs.version_override_cargo }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          py_version = os.environ["PY_VERSION"].strip()
+          cargo_version = os.environ["CARGO_VERSION"].strip()
+          if not py_version or not cargo_version:
+            raise SystemExit("Expected both version overrides to be set together")
+
+          pyproject_path = Path("pyproject.toml")
+          pyproject_text = pyproject_path.read_text(encoding="utf-8")
+          current_py_version = tomllib.loads(pyproject_text)["project"]["version"]
+          updated_pyproject = pyproject_text.replace(
+            f'version = "{current_py_version}"',
+            f'version = "{py_version}"',
+            1,
+          )
+          if updated_pyproject == pyproject_text:
+            raise SystemExit("Failed to update pyproject.toml version")
+          pyproject_path.write_text(updated_pyproject, encoding="utf-8")
+
+          cargo_path = Path("Cargo.toml")
+          cargo_text = cargo_path.read_text(encoding="utf-8")
+          current_cargo_version = tomllib.loads(cargo_text)["package"]["version"]
+          updated_cargo = cargo_text.replace(
+            f'version = "{current_cargo_version}"',
+            f'version = "{cargo_version}"',
+            1,
+          )
+          if updated_cargo == cargo_text:
+            raise SystemExit("Failed to update Cargo.toml version")
+          cargo_path.write_text(updated_cargo, encoding="utf-8")
+          PY
 
       - uses: pnpm/action-setup@v5
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -54,7 +54,7 @@ jobs:
           CARGO_VERSION: ${{ inputs.version_override_cargo }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/apply_version_overrides.py "$PY_VERSION" "$CARGO_VERSION"
+          python .github/scripts/apply_version_overrides.py "$PY_VERSION" "$CARGO_VERSION"
 
       - uses: pnpm/action-setup@v5
         with:
@@ -168,7 +168,7 @@ jobs:
           CARGO_VERSION: ${{ inputs.version_override_cargo }}
         run: |
           set -euo pipefail
-          python3 .github/scripts/apply_version_overrides.py "$PY_VERSION" "$CARGO_VERSION"
+          python .github/scripts/apply_version_overrides.py "$PY_VERSION" "$CARGO_VERSION"
 
       - uses: pnpm/action-setup@v5
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -54,40 +54,7 @@ jobs:
           CARGO_VERSION: ${{ inputs.version_override_cargo }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import os
-          import tomllib
-          from pathlib import Path
-
-          py_version = os.environ["PY_VERSION"].strip()
-          cargo_version = os.environ["CARGO_VERSION"].strip()
-          if not py_version or not cargo_version:
-            raise SystemExit("Expected both version overrides to be set together")
-
-          pyproject_path = Path("pyproject.toml")
-          pyproject_text = pyproject_path.read_text(encoding="utf-8")
-          current_py_version = tomllib.loads(pyproject_text)["project"]["version"]
-          updated_pyproject = pyproject_text.replace(
-            f'version = "{current_py_version}"',
-            f'version = "{py_version}"',
-            1,
-          )
-          if updated_pyproject == pyproject_text:
-            raise SystemExit("Failed to update pyproject.toml version")
-          pyproject_path.write_text(updated_pyproject, encoding="utf-8")
-
-          cargo_path = Path("Cargo.toml")
-          cargo_text = cargo_path.read_text(encoding="utf-8")
-          current_cargo_version = tomllib.loads(cargo_text)["package"]["version"]
-          updated_cargo = cargo_text.replace(
-            f'version = "{current_cargo_version}"',
-            f'version = "{cargo_version}"',
-            1,
-          )
-          if updated_cargo == cargo_text:
-            raise SystemExit("Failed to update Cargo.toml version")
-          cargo_path.write_text(updated_cargo, encoding="utf-8")
-          PY
+          python3 .github/scripts/apply_version_overrides.py "$PY_VERSION" "$CARGO_VERSION"
 
       - uses: pnpm/action-setup@v5
         with:
@@ -201,40 +168,7 @@ jobs:
           CARGO_VERSION: ${{ inputs.version_override_cargo }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import os
-          import tomllib
-          from pathlib import Path
-
-          py_version = os.environ["PY_VERSION"].strip()
-          cargo_version = os.environ["CARGO_VERSION"].strip()
-          if not py_version or not cargo_version:
-            raise SystemExit("Expected both version overrides to be set together")
-
-          pyproject_path = Path("pyproject.toml")
-          pyproject_text = pyproject_path.read_text(encoding="utf-8")
-          current_py_version = tomllib.loads(pyproject_text)["project"]["version"]
-          updated_pyproject = pyproject_text.replace(
-            f'version = "{current_py_version}"',
-            f'version = "{py_version}"',
-            1,
-          )
-          if updated_pyproject == pyproject_text:
-            raise SystemExit("Failed to update pyproject.toml version")
-          pyproject_path.write_text(updated_pyproject, encoding="utf-8")
-
-          cargo_path = Path("Cargo.toml")
-          cargo_text = cargo_path.read_text(encoding="utf-8")
-          current_cargo_version = tomllib.loads(cargo_text)["package"]["version"]
-          updated_cargo = cargo_text.replace(
-            f'version = "{current_cargo_version}"',
-            f'version = "{cargo_version}"',
-            1,
-          )
-          if updated_cargo == cargo_text:
-            raise SystemExit("Failed to update Cargo.toml version")
-          cargo_path.write_text(updated_cargo, encoding="utf-8")
-          PY
+          python3 .github/scripts/apply_version_overrides.py "$PY_VERSION" "$CARGO_VERSION"
 
       - uses: pnpm/action-setup@v5
         with:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,10 +11,74 @@ on:
         options:
           - testpypi
           - pypi
+      test_version_suffix:
+        description: "Optional TestPyPI dev serial (digits only). Publishes <base>.devN."
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
 jobs:
+  version-plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      package_version: ${{ steps.plan.outputs.package_version }}
+      cargo_version: ${{ steps.plan.outputs.cargo_version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Determine publish versions
+        id: plan
+        shell: bash
+        env:
+          PUBLISH_TARGET: ${{ inputs.publish_target }}
+          TEST_VERSION_SUFFIX: ${{ inputs.test_version_suffix }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import re
+          import tomllib
+
+          with open("pyproject.toml", "rb") as fh:
+            pyproject = tomllib.load(fh)
+          with open("Cargo.toml", "rb") as fh:
+            cargo = tomllib.load(fh)
+
+          base_python = pyproject["project"]["version"]
+          base_cargo = cargo["package"]["version"]
+
+          if base_python != base_cargo:
+            raise SystemExit(
+              f"Version mismatch in repo: pyproject.toml={base_python} Cargo.toml={base_cargo}"
+            )
+
+          suffix = os.environ["TEST_VERSION_SUFFIX"].strip()
+          publish_target = os.environ["PUBLISH_TARGET"]
+
+          package_version = base_python
+          cargo_version = base_cargo
+
+          if suffix:
+            if publish_target != "testpypi":
+              raise SystemExit("test_version_suffix is only supported for testpypi publishes")
+            if not re.fullmatch(r"[0-9]+", suffix):
+              raise SystemExit("test_version_suffix must contain digits only")
+            package_version = f"{base_python}.dev{suffix}"
+            cargo_version = f"{base_cargo}-dev.{suffix}"
+
+          github_output = os.environ["GITHUB_OUTPUT"]
+          with open(github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"package_version={package_version}\n")
+            fh.write(f"cargo_version={cargo_version}\n")
+
+          print(f"Package version: {package_version}")
+          print(f"Cargo version: {cargo_version}")
+          PY
+
   pypi-readme:
     uses: ./.github/workflows/render-pypi-readme.yml
     permissions:
@@ -33,7 +97,9 @@ jobs:
       artifact_name: pypi-readme
 
   build:
-    needs: pypi-readme
+    needs:
+      - version-plan
+      - pypi-readme
     uses: ./.github/workflows/build-wheels.yml
     permissions:
       contents: read
@@ -41,9 +107,13 @@ jobs:
       upload_artifacts: true
       use_pypi_readme: true
       pypi_readme_artifact_name: pypi-readme
+      version_override_python: ${{ needs.version-plan.outputs.package_version }}
+      version_override_cargo: ${{ needs.version-plan.outputs.cargo_version }}
 
   upload:
-    needs: build
+    needs:
+      - version-plan
+      - build
     runs-on: ubuntu-latest
     # Configure matching trusted publishers on PyPI and TestPyPI for this
     # workflow path and the corresponding GitHub environment name.
@@ -51,8 +121,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    outputs:
-      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v5
 
@@ -73,6 +141,16 @@ jobs:
         with:
           enable-cache: false
 
+      - name: Show publish version
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.version-plan.outputs.package_version }}
+          CARGO_VERSION: ${{ needs.version-plan.outputs.cargo_version }}
+        run: |
+          set -euo pipefail
+          echo "Publishing package version: $PACKAGE_VERSION"
+          echo "Using cargo package version: $CARGO_VERSION"
+
       - name: Upload distributions with trusted publishing
         shell: bash
         run: |
@@ -89,23 +167,10 @@ jobs:
             --trusted-publishing always \
             dist/*
 
-      - name: Determine version
-        id: version
-        run: |
-          python - <<'PY'
-          import os
-          import tomllib
-
-          with open("pyproject.toml", "rb") as fh:
-            data = tomllib.load(fh)
-          version = data["project"]["version"]
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-            fh.write(f"version={version}\n")
-          print(f"Detected version: {version}")
-          PY
-
   qa-install:
-    needs: upload
+    needs:
+      - version-plan
+      - upload
     if: ${{ inputs.publish_target == 'testpypi' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -127,7 +192,7 @@ jobs:
       - name: Install from TestPyPI (no build)
         shell: bash
         env:
-          VERSION: ${{ needs.upload.outputs.version }}
+          VERSION: ${{ needs.version-plan.outputs.package_version }}
         run: |
           set -euo pipefail
           echo "Testing install for agent-bus-mcp==$VERSION on $RUNNER_OS"
@@ -148,7 +213,9 @@ jobs:
           exit 1
 
   tag-release:
-    needs: upload
+    needs:
+      - version-plan
+      - upload
     if: ${{ inputs.publish_target == 'pypi' }}
     runs-on: ubuntu-latest
     permissions:
@@ -161,7 +228,7 @@ jobs:
 
       - name: Create annotated tag
         env:
-          VERSION: ${{ needs.upload.outputs.version }}
+          VERSION: ${{ needs.version-plan.outputs.package_version }}
         run: |
           set -euo pipefail
           tag="v${VERSION}"

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -67,6 +67,8 @@ jobs:
               raise SystemExit("test_version_suffix is only supported for testpypi publishes")
             if not re.fullmatch(r"[0-9]+", suffix):
               raise SystemExit("test_version_suffix must contain digits only")
+            if len(suffix) > 1 and suffix.startswith("0"):
+              raise SystemExit("test_version_suffix must not contain leading zeros")
             package_version = f"{base_python}.dev{suffix}"
             cargo_version = f"{base_cargo}-dev.{suffix}"
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -109,8 +109,8 @@ jobs:
       upload_artifacts: true
       use_pypi_readme: true
       pypi_readme_artifact_name: pypi-readme
-      version_override_python: ${{ needs.version-plan.outputs.package_version }}
-      version_override_cargo: ${{ needs.version-plan.outputs.cargo_version }}
+      version_override_python: ${{ inputs.publish_target == 'testpypi' && inputs.test_version_suffix != '' && needs.version-plan.outputs.package_version || '' }}
+      version_override_cargo: ${{ inputs.publish_target == 'testpypi' && inputs.test_version_suffix != '' && needs.version-plan.outputs.cargo_version || '' }}
 
   upload:
     needs:


### PR DESCRIPTION
## Summary
- add a `test_version_suffix` input to `publish-testpypi`
- derive TestPyPI-only prerelease versions like `0.4.2.dev7` / `0.4.2-dev.7`
- thread those overrides through the reusable wheel build, upload, qa-install, and tag logic

## Why
The recent TestPyPI failure was not an auth problem. The workflow retried publishing `0.4.2`, but TestPyPI already had artifacts with the same filenames and different hashes, so `uv publish` correctly rejected the upload.

This change gives us a safe, repeatable way to test trusted publishing on TestPyPI without mutating repository version files or reusing an already-published release version.

## How to test
1. Run `publish-testpypi`
2. Set `publish_target=testpypi`
3. Set `test_version_suffix` to a new integer like `8`
4. Confirm the workflow publishes `0.4.2.dev8` and the `qa-install` jobs install that exact version from TestPyPI

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-testpypi.yml"); YAML.load_file(".github/workflows/build-wheels.yml"); puts "yaml-ok"'`
- `git diff --check`
- `uv run ty check`
- disposable local `maturin sdist` with overrides -> `agent_bus_mcp-0.4.2.dev7.tar.gz`
- disposable local `maturin build` with overrides -> `agent_bus_mcp-0.4.2.dev7-...whl`
