### PR TITLE
ci: skip duplicate site build on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   site:
+    # PRs and manual runs should validate the docs build, but main pushes already
+    # rebuild the site in publish-docs-site before deploying to GitHub Pages.
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- skip the `ci` workflow's `site` job on `push` to `main`
- keep docs-site validation on pull requests and manual workflow dispatches
- leave `publish-docs-site` as the only post-merge site build/deploy path on `main`

## Why
Merging the docs-site PR currently triggers two site builds for the same `main` commit:
- `ci` -> `site`
- `publish-docs-site` -> `build`

This change removes the duplicate post-merge build without reducing PR coverage.

## How to test
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/publish-docs-site.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/publish-docs-site.yml")'`
- `git diff --check`

## Expected behavior
- PRs still run the `site` job in `ci`
- `workflow_dispatch` still runs the `site` job in `ci`
- pushes to `main` skip the `site` job in `ci`
- pushes to `main` still build and deploy the site via `publish-docs-site`
