### PR TITLE
docs: refresh docs site navigation and reference pages

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,6 +39,7 @@ on:
 env:
   ORT_VERSION: "1.23.2"
   NODE_VERSION: "24"
+  MATURIN_VERSION: "v1.11.5"
 
 jobs:
   sdist:
@@ -135,9 +136,10 @@ jobs:
         run: pnpm --dir frontend build
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: sdist
+          maturin-version: ${{ env.MATURIN_VERSION }}
           args: --out dist
 
       - name: Upload sdist
@@ -222,27 +224,30 @@ jobs:
 
       - name: Build wheels (Linux, manylinux_2_28)
         if: runner.os == 'Linux'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
+          maturin-version: ${{ env.MATURIN_VERSION }}
           # manylinux builds run in a container, so pin the interpreter here.
           args: --release --out dist -i python3.12
           manylinux: 2_28
 
       - name: Build wheels (Linux, manylinux_2_28 aarch64)
         if: runner.os == 'Linux'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
+          maturin-version: ${{ env.MATURIN_VERSION }}
           args: --release --out dist -i python3.12
           manylinux: 2_28
           target: aarch64-unknown-linux-gnu
 
       - name: Build wheels (macOS/Windows)
         if: runner.os != 'Linux'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
+          maturin-version: ${{ env.MATURIN_VERSION }}
           args: --release --out dist
 
       - name: Upload wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   site:
+    # PRs and manual runs should validate the docs build, but main pushes already
+    # rebuild the site in publish-docs-site before deploying to GitHub Pages.
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,9 @@ Use these sections when you need more depth:
 
 - [Tutorials](tutorials/first-topic-between-two-peers.md): work through a full handoff from start to finish
 - [How-to guides](how-to/install-and-configure-agent-bus.md): complete setup and operational tasks
-- [Reference](reference/runtime-reference.md): check tool names, commands, environment variables, and exact behavior
-- [Explanation](explanation/why-agent-bus.md): understand the design and where it fits best
+- [Reference](reference/runtime-reference.md): check tool names, commands, and exact behavior
+- [FAQ](explanation/why-agent-bus.md): understand the design, fit boundaries, and common questions
 
 If you already know the task and only need exact details, use
-[Runtime reference](reference/runtime-reference.md) or the raw [implementation spec](../spec.md).
+[Runtime reference](reference/runtime-reference.md), [Search and embeddings reference](reference/search-and-embeddings-reference.md),
+or the raw [implementation spec](../spec.md).

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -1,6 +1,6 @@
-# Explanation
+# FAQ
 
-Read this section when you want the rationale behind the topic model, the local-first design, and
-the system boundaries.
+Read this section when you want the rationale behind the topic model, the local-first design, the
+system boundaries, and answers to common questions.
 
 - [Why use Agent Bus?](why-agent-bus.md)

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -5,4 +5,5 @@ Use these guides when you already know the task you want to complete:
 - [Install and configure Agent Bus](install-and-configure-agent-bus.md)
 - [Use the Agent Bus Web UI](use-the-web-ui.md)
 
-Need exact command names or settings? See [Runtime reference](../reference/runtime-reference.md).
+Need exact command names? See [Runtime reference](../reference/runtime-reference.md). Need search or
+embedding settings? See [Search and embeddings reference](../reference/search-and-embeddings-reference.md).

--- a/docs/how-to/install-and-configure-agent-bus.md
+++ b/docs/how-to/install-and-configure-agent-bus.md
@@ -4,6 +4,7 @@ This guide gets Agent Bus running in a local MCP client. Start with the publishe
 you are developing Agent Bus itself.
 
 ## Fastest path: run the published package with `uvx`
+<!-- site-wrap: package -->
 
 Check that the published package runs:
 
@@ -14,6 +15,7 @@ uvx --from "agent-bus-mcp==<version>" agent-bus --help
 Then add it to your MCP client.
 
 ## Add Agent Bus to a client
+<!-- site-wrap: client -->
 
 For long-lived client configuration, pin the package version.
 
@@ -73,6 +75,7 @@ gemini mcp add agent-bus uvx -- --from agent-bus-mcp==<version> agent-bus
 ```
 
 ## Share the same database between clients
+<!-- site-wrap: database -->
 
 By default, Agent Bus uses `~/.agent_bus/agent_bus.sqlite`.
 
@@ -91,6 +94,7 @@ uvx --refresh-package agent-bus-mcp --from agent-bus-mcp agent-bus
 ```
 
 ## Run from a local checkout
+<!-- site-wrap: checkout -->
 
 Use a local checkout when testing unreleased changes or developing Agent Bus itself.
 
@@ -109,6 +113,7 @@ uv run maturin develop
 ```
 
 ## Optional: enable the Web UI
+<!-- site-wrap: webui -->
 
 The Web UI requires the `web` extras.
 
@@ -133,6 +138,7 @@ before you start the server.
 For daily browser workflows after setup, see [How to use the Agent Bus Web UI](use-the-web-ui.md).
 
 ## Optional: install the `agent-bus-workflows` skill
+<!-- site-wrap: workflow -->
 
 This repo ships an optional workflow skill for reviewer/implementer loops, handoffs, duplicate-name
 recovery, and reclaim-token reconnects.

--- a/docs/how-to/use-the-web-ui.md
+++ b/docs/how-to/use-the-web-ui.md
@@ -4,6 +4,7 @@ Use this guide when you want to browse topics, read message history, search acro
 export a thread from the local browser workbench.
 
 ## Start the Web UI
+<!-- site-wrap: start -->
 
 You need a running Agent Bus database and a frontend bundle.
 
@@ -34,6 +35,7 @@ uv run agent-bus serve --db-path /path/to/agent_bus.sqlite
 Then open `http://127.0.0.1:8080`.
 
 ## Find a topic
+<!-- site-wrap: find -->
 
 The default workbench starts with a sidebar of recent topics and a main area for search and
 orientation.
@@ -57,6 +59,7 @@ Use the sidebar to:
 </p>
 
 ## Open a thread
+<!-- site-wrap: thread -->
 
 Selecting a topic opens the thread view. Use it to review message history and inspect topic
 metadata in one place.
@@ -81,6 +84,7 @@ From here you can:
 - load earlier messages when the thread is longer than the current window
 
 ## Search the bus
+<!-- site-wrap: search -->
 
 Use the sidebar search field to find topics by name.
 
@@ -90,6 +94,7 @@ For message content lookup, open a topic and use the thread search controls. Use
 need exact lexical, hybrid, or semantic search behavior across the bus.
 
 ## Export a topic
+<!-- site-wrap: export -->
 
 Open the thread you want, then use the `Export` action in the topic header.
 
@@ -97,6 +102,7 @@ This downloads a browser-friendly export of the selected topic so you can archiv
 review a past session outside the live workbench.
 
 ## Troubleshooting
+<!-- site-wrap: troubleshooting -->
 
 ### Frontend bundle not found
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,5 +4,6 @@ Use this section for exact commands, tool names, configuration values, and repos
 reference material.
 
 - [Runtime reference](runtime-reference.md)
+- [Search and embeddings reference](search-and-embeddings-reference.md)
 - [Implementation spec](../../spec.md)
 - [Changelog](../../CHANGELOG.md)

--- a/docs/reference/runtime-reference.md
+++ b/docs/reference/runtime-reference.md
@@ -1,6 +1,15 @@
 # Runtime reference
 
-Use this page for exact MCP tool, CLI, search, and configuration details.
+Use this page for exact MCP tool and CLI details.
+
+If you need search modes, embedding commands, or embedding-related environment variables, use
+[Search and embeddings reference](search-and-embeddings-reference.md).
+
+Use this page when you need to:
+
+- check which MCP tool handles a task
+- copy a common CLI command
+- confirm a tool-side behavior such as topic reuse, replay, or reclaim tokens
 
 ## MCP tools
 
@@ -23,10 +32,17 @@ Use this page for exact MCP tool, CLI, search, and configuration details.
 
 ## Common CLI commands
 
+### Inspect topics
+
 ```bash
 agent-bus cli topics list --status all
 agent-bus cli topics watch <topic_id> --follow
 agent-bus cli topics presence <topic_id>
+```
+
+### Topic admin
+
+```bash
 agent-bus cli topics rename <topic_id> <new_name>
 agent-bus cli topics delete <topic_id> --yes
 agent-bus cli db wipe --yes
@@ -35,67 +51,9 @@ agent-bus cli db wipe --yes
 `topics rename` rewrites message content by default by replacing occurrences of the old topic name
 with the new one. Use `--no-rewrite-messages` to disable that behavior.
 
-## Search modes
-
-Lexical search works out of the box through SQLite FTS5. Hybrid and semantic search use local
-embeddings through `fastembed` in the Rust core.
-
-```bash
-agent-bus cli search "cursor reset"                 # hybrid (default)
-agent-bus cli search "sqlite wal" --mode fts        # lexical only
-agent-bus cli search "replay history" --mode semantic
-agent-bus cli search "poll backoff" --topic-id <topic_id>
-```
-
-To index embeddings for existing messages:
-
-```bash
-uvx --from agent-bus-mcp agent-bus cli embeddings index
-```
-
-From a local checkout:
-
-```bash
-uv sync
-uv run agent-bus cli embeddings index
-```
-
-## Configuration
-
-| Variable | Purpose |
-| --- | --- |
-| `AGENT_BUS_DB` | SQLite DB path (default: `~/.agent_bus/agent_bus.sqlite`) |
-| `AGENT_BUS_MAX_OUTBOX` | Max outbound items per sync call (default: `50`) |
-| `AGENT_BUS_MAX_MESSAGE_CHARS` | Max message size (default: `65536`) |
-| `AGENT_BUS_TOOL_TEXT_INCLUDE_BODIES` | Include full bodies in tool text output (default: `1`) |
-| `AGENT_BUS_TOOL_TEXT_MAX_CHARS` | Max chars per message in tool text output (default: `64000`) |
-| `AGENT_BUS_MAX_SYNC_ITEMS` | Max allowed `sync(max_items=...)` (default: `20`) |
-| `AGENT_BUS_POLL_INITIAL_MS` | Initial poll backoff (default: `250`) |
-| `AGENT_BUS_POLL_MAX_MS` | Max poll backoff (default: `1000`) |
-| `AGENT_BUS_EMBEDDINGS_AUTOINDEX` | Enqueue and index embeddings for new messages (default: `1`) |
-| `AGENT_BUS_EMBEDDING_MODEL` | Embedding model alias or identifier |
-| `AGENT_BUS_EMBEDDING_MAX_TOKENS` | Max embedding tokens (default: `512`, max: `8192`) |
-| `AGENT_BUS_EMBEDDING_CHUNK_SIZE` | Chunk size for embedding input (default: `1200`) |
-| `AGENT_BUS_EMBEDDING_CHUNK_OVERLAP` | Chunk overlap for embeddings (default: `200`) |
-| `AGENT_BUS_EMBEDDING_CACHE_DIR` | Override the bus-specific `fastembed` cache directory |
-| `FASTEMBED_CACHE_DIR` | Standard `fastembed` cache override |
-| `AGENT_BUS_EMBEDDINGS_WORKER_BATCH_SIZE` | Embedding worker batch size (default: `5`) |
-| `AGENT_BUS_EMBEDDINGS_POLL_MS` | Idle worker poll interval (default: `250`) |
-| `AGENT_BUS_EMBEDDINGS_LOCK_TTL_SECONDS` | Embedding job lock TTL (default: `300`) |
-| `AGENT_BUS_EMBEDDINGS_ERROR_RETRY_SECONDS` | Retry delay after indexing errors (default: `30`) |
-| `AGENT_BUS_EMBEDDINGS_MAX_ATTEMPTS` | Max embedding attempts per message (default: `5`) |
-| `AGENT_BUS_EMBEDDINGS_LEADER_TTL_SECONDS` | Lease TTL for the active embedding worker (default: `30`) |
-| `AGENT_BUS_EMBEDDINGS_LEADER_HEARTBEAT_SECONDS` | Lease heartbeat interval (default: `10`) |
-
-Supported embedding model aliases include:
-
-- `sentence-transformers/all-MiniLM-L6-v2`
-- `sentence-transformers/all-mpnet-base-v2`
-- `BAAI/bge-small-en-v1.5`
-- `intfloat/multilingual-e5-small`
-
 ## See also
 
+- [Search and embeddings reference](search-and-embeddings-reference.md)
 - [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md)
 - [Implementation spec](../../spec.md)
 - [Changelog](../../CHANGELOG.md)

--- a/docs/reference/search-and-embeddings-reference.md
+++ b/docs/reference/search-and-embeddings-reference.md
@@ -1,0 +1,96 @@
+# Search and embeddings reference
+
+Use this page for exact search modes, indexing commands, and embedding-related configuration.
+
+Use this page when you need to:
+
+- choose between `fts`, `hybrid`, and `semantic`
+- backfill embeddings for existing history
+- find the environment variable that controls chunking, polling, retries, or cache paths
+
+## Search modes
+
+- `fts`: lexical search through SQLite FTS5
+- `hybrid`: the default mode, combining lexical and vector recall
+- `semantic`: vector-only matching through local embeddings
+
+```bash
+agent-bus cli search "cursor reset"                 # hybrid (default)
+agent-bus cli search "sqlite wal" --mode fts        # lexical only
+agent-bus cli search "replay history" --mode semantic
+agent-bus cli search "poll backoff" --topic-id <topic_id>
+```
+
+FTS works without embeddings. Hybrid and semantic search improve after vectors are indexed.
+
+## Backfill embeddings for existing messages
+
+From a published package:
+
+```bash
+uvx --from agent-bus-mcp agent-bus cli embeddings index
+```
+
+From a local checkout:
+
+```bash
+uv sync
+uv run agent-bus cli embeddings index
+```
+
+## Configuration
+
+### Storage and limits
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_DB` | SQLite DB path (default: `~/.agent_bus/agent_bus.sqlite`) |
+| `AGENT_BUS_MAX_OUTBOX` | Max outbound items per sync call (default: `50`) |
+| `AGENT_BUS_MAX_MESSAGE_CHARS` | Max message size (default: `65536`) |
+| `AGENT_BUS_MAX_SYNC_ITEMS` | Max allowed `sync(max_items=...)` (default: `20`) |
+
+### Tool text output
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_TOOL_TEXT_INCLUDE_BODIES` | Include full bodies in tool text output (default: `1`) |
+| `AGENT_BUS_TOOL_TEXT_MAX_CHARS` | Max chars per message in tool text output (default: `64000`) |
+
+### Polling
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_POLL_INITIAL_MS` | Initial poll backoff (default: `250`) |
+| `AGENT_BUS_POLL_MAX_MS` | Max poll backoff (default: `1000`) |
+
+### Embeddings
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_EMBEDDINGS_AUTOINDEX` | Enqueue and index embeddings for new messages (default: `1`) |
+| `AGENT_BUS_EMBEDDING_MODEL` | Embedding model alias or identifier |
+| `AGENT_BUS_EMBEDDING_MAX_TOKENS` | Max embedding tokens (default: `512`, max: `8192`) |
+| `AGENT_BUS_EMBEDDING_CHUNK_SIZE` | Chunk size for embedding input (default: `1200`) |
+| `AGENT_BUS_EMBEDDING_CHUNK_OVERLAP` | Chunk overlap for embeddings (default: `200`) |
+| `AGENT_BUS_EMBEDDING_CACHE_DIR` | Override the bus-specific `fastembed` cache directory |
+| `FASTEMBED_CACHE_DIR` | Standard `fastembed` cache override |
+| `AGENT_BUS_EMBEDDINGS_WORKER_BATCH_SIZE` | Embedding worker batch size (default: `5`) |
+| `AGENT_BUS_EMBEDDINGS_POLL_MS` | Idle worker poll interval (default: `250`) |
+| `AGENT_BUS_EMBEDDINGS_LOCK_TTL_SECONDS` | Embedding job lock TTL (default: `300`) |
+| `AGENT_BUS_EMBEDDINGS_ERROR_RETRY_SECONDS` | Retry delay after indexing errors (default: `30`) |
+| `AGENT_BUS_EMBEDDINGS_MAX_ATTEMPTS` | Max embedding attempts per message (default: `5`) |
+| `AGENT_BUS_EMBEDDINGS_LEADER_TTL_SECONDS` | Lease TTL for the active embedding worker (default: `30`) |
+| `AGENT_BUS_EMBEDDINGS_LEADER_HEARTBEAT_SECONDS` | Lease heartbeat interval (default: `10`) |
+
+Supported embedding model aliases include:
+
+- `sentence-transformers/all-MiniLM-L6-v2`
+- `sentence-transformers/all-mpnet-base-v2`
+- `BAAI/bge-small-en-v1.5`
+- `intfloat/multilingual-e5-small`
+
+## See also
+
+- [Runtime reference](runtime-reference.md)
+- [Implementation spec](../../spec.md)
+- [Changelog](../../CHANGELOG.md)

--- a/scripts/generate_fumadocs_site.py
+++ b/scripts/generate_fumadocs_site.py
@@ -30,22 +30,12 @@ ATTR_RE = re.compile(r'([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*"([^"]*)"')
 TUTORIAL_STEPS_PAGE = PurePosixPath("docs/tutorials/first-topic-between-two-peers.md")
 INSTALL_GUIDE_PAGE = PurePosixPath("docs/how-to/install-and-configure-agent-bus.md")
 WEB_UI_GUIDE_PAGE = PurePosixPath("docs/how-to/use-the-web-ui.md")
-INSTALL_SECTION_VARIANTS = {
-    "Fastest path: run the published package with `uvx`": "package",
-    "Add Agent Bus to a client": "client",
-    "Share the same database between clients": "database",
-    "Run from a local checkout": "checkout",
-    "Optional: enable the Web UI": "webui",
-    "Optional: install the `agent-bus-workflows` skill": "workflow",
-}
-WEB_UI_SECTION_VARIANTS = {
-    "Start the Web UI": "start",
-    "Find a topic": "find",
-    "Open a thread": "thread",
-    "Search the bus": "search",
-    "Export a topic": "export",
-    "Troubleshooting": "troubleshooting",
-}
+INSTALL_SECTION_VARIANTS = frozenset(
+    {"package", "client", "database", "checkout", "webui", "workflow"}
+)
+WEB_UI_SECTION_VARIANTS = frozenset(
+    {"start", "find", "thread", "search", "export", "troubleshooting"}
+)
 
 
 @dataclass(frozen=True)
@@ -341,14 +331,13 @@ def wrap_tutorial_steps(text: str) -> str:
     return f"{before}\n\n{wrapped}\n\n{after}"
 
 
-def wrap_marked_sections(text: str, component_name: str, variant_map: dict[str, str]) -> str:
+def wrap_marked_sections(text: str, component_name: str, valid_variants: frozenset[str]) -> str:
     heading_matches = list(re.finditer(r"(?m)^## (.+)$", text))
     if not heading_matches:
         return text
 
     result: list[str] = []
     cursor = 0
-    valid_variants = set(variant_map.values())
     marker_re = re.compile(
         r"\A(## [^\n]+\n)<!--\s*site-wrap:\s*([a-z0-9-]+)\s*-->\n+", re.IGNORECASE
     )

--- a/scripts/generate_fumadocs_site.py
+++ b/scripts/generate_fumadocs_site.py
@@ -312,11 +312,20 @@ def apply_site_only_page_transforms(text: str, source_rel: PurePosixPath) -> str
 
 
 def wrap_tutorial_steps(text: str) -> str:
-    start_marker = "## Step 1: connect Agent Bus in both clients"
-    end_marker = "## What you just learned"
-    start = text.find(start_marker)
-    end = text.find(end_marker)
-    if start == -1 or end == -1 or end <= start:
+    step_heading_re = re.compile(r"(?m)^## Step \d+: .*$")
+    h2_heading_re = re.compile(r"(?m)^## .*$")
+
+    start_match = step_heading_re.search(text)
+    if start_match is None:
+        return text
+
+    start = start_match.start()
+    end = len(text)
+    for heading_match in h2_heading_re.finditer(text, start_match.end()):
+        if not step_heading_re.fullmatch(heading_match.group(0)):
+            end = heading_match.start()
+            break
+    if end <= start:
         return text
 
     before = text[:start].rstrip()

--- a/scripts/generate_fumadocs_site.py
+++ b/scripts/generate_fumadocs_site.py
@@ -213,9 +213,7 @@ def relative_asset_href(target_rel: PurePosixPath, repo_rel: PurePosixPath) -> s
 
 
 def rewrite_html_images(text: str, source_rel: PurePosixPath, target_rel: PurePosixPath) -> str:
-    def rewrite_attrs(
-        match: re.Match[str], tag_name: str, attr_name: str
-    ) -> str:
+    def rewrite_attrs(match: re.Match[str], tag_name: str, attr_name: str) -> str:
         attrs = ATTR_RE.findall(match.group(1))
         rewritten: list[tuple[str, str]] = []
         target_found = False
@@ -343,9 +341,7 @@ def wrap_tutorial_steps(text: str) -> str:
     return f"{before}\n\n{wrapped}\n\n{after}"
 
 
-def wrap_named_sections(
-    text: str, component_name: str, variant_map: dict[str, str]
-) -> str:
+def wrap_named_sections(text: str, component_name: str, variant_map: dict[str, str]) -> str:
     heading_matches = list(re.finditer(r"(?m)^## (.+)$", text))
     if not heading_matches:
         return text
@@ -355,7 +351,9 @@ def wrap_named_sections(
 
     for index, match in enumerate(heading_matches):
         title = match.group(1).strip()
-        next_start = heading_matches[index + 1].start() if index + 1 < len(heading_matches) else len(text)
+        next_start = (
+            heading_matches[index + 1].start() if index + 1 < len(heading_matches) else len(text)
+        )
         section = text[match.start() : next_start].strip()
         result.append(text[cursor : match.start()])
         cursor = next_start

--- a/scripts/generate_fumadocs_site.py
+++ b/scripts/generate_fumadocs_site.py
@@ -303,9 +303,9 @@ def apply_site_only_page_transforms(text: str, source_rel: PurePosixPath) -> str
     if source_rel == TUTORIAL_STEPS_PAGE:
         text = wrap_tutorial_steps(text)
     if source_rel == INSTALL_GUIDE_PAGE:
-        text = wrap_named_sections(text, "InstallSection", INSTALL_SECTION_VARIANTS)
+        text = wrap_marked_sections(text, "InstallSection", INSTALL_SECTION_VARIANTS)
     if source_rel == WEB_UI_GUIDE_PAGE:
-        text = wrap_named_sections(text, "WebUiSection", WEB_UI_SECTION_VARIANTS)
+        text = wrap_marked_sections(text, "WebUiSection", WEB_UI_SECTION_VARIANTS)
     return text
 
 
@@ -341,16 +341,19 @@ def wrap_tutorial_steps(text: str) -> str:
     return f"{before}\n\n{wrapped}\n\n{after}"
 
 
-def wrap_named_sections(text: str, component_name: str, variant_map: dict[str, str]) -> str:
+def wrap_marked_sections(text: str, component_name: str, variant_map: dict[str, str]) -> str:
     heading_matches = list(re.finditer(r"(?m)^## (.+)$", text))
     if not heading_matches:
         return text
 
     result: list[str] = []
     cursor = 0
+    valid_variants = set(variant_map.values())
+    marker_re = re.compile(
+        r"\A(## [^\n]+\n)<!--\s*site-wrap:\s*([a-z0-9-]+)\s*-->\n+", re.IGNORECASE
+    )
 
     for index, match in enumerate(heading_matches):
-        title = match.group(1).strip()
         next_start = (
             heading_matches[index + 1].start() if index + 1 < len(heading_matches) else len(text)
         )
@@ -358,10 +361,16 @@ def wrap_named_sections(text: str, component_name: str, variant_map: dict[str, s
         result.append(text[cursor : match.start()])
         cursor = next_start
 
-        variant = variant_map.get(title)
-        if variant:
+        marker_match = marker_re.match(section)
+        variant = marker_match.group(2).lower() if marker_match else None
+        if variant in valid_variants:
+            cleaned_section = (
+                f"{marker_match.group(1)}{section[marker_match.end() :]}"
+                if marker_match
+                else section
+            )
             result.append(
-                f'<{component_name} variant="{variant}">\n\n{section}\n\n</{component_name}>\n\n'
+                f'<{component_name} variant="{variant}">\n\n{cleaned_section}\n\n</{component_name}>\n\n'
             )
         else:
             result.append(section)

--- a/scripts/generate_fumadocs_site.py
+++ b/scripts/generate_fumadocs_site.py
@@ -15,6 +15,9 @@ SPECIAL_PAGES = {
     PurePosixPath("spec.md"): PurePosixPath("reference/implementation-spec.mdx"),
     PurePosixPath("CHANGELOG.md"): PurePosixPath("reference/changelog.mdx"),
 }
+PAGE_TITLE_OVERRIDES = {
+    PurePosixPath("spec.md"): "Implementation spec",
+}
 ASSET_SOURCE_ROOT = PurePosixPath("docs/images")
 ASSET_TARGET_ROOT = PurePosixPath("docs-assets/images")
 
@@ -22,7 +25,27 @@ FENCE_RE = re.compile(r"(?ms)^```.*?^```[ \t]*\n?")
 MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)(?:\s+\"([^\"]*)\")?\)")
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)\s]+)(?:\s+\"([^\"]*)\")?\)")
 HTML_IMAGE_RE = re.compile(r"(?is)<img\b([^>]*?)\/?>")
+HTML_SOURCE_RE = re.compile(r"(?is)<source\b([^>]*?)\/?>")
 ATTR_RE = re.compile(r'([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*"([^"]*)"')
+TUTORIAL_STEPS_PAGE = PurePosixPath("docs/tutorials/first-topic-between-two-peers.md")
+INSTALL_GUIDE_PAGE = PurePosixPath("docs/how-to/install-and-configure-agent-bus.md")
+WEB_UI_GUIDE_PAGE = PurePosixPath("docs/how-to/use-the-web-ui.md")
+INSTALL_SECTION_VARIANTS = {
+    "Fastest path: run the published package with `uvx`": "package",
+    "Add Agent Bus to a client": "client",
+    "Share the same database between clients": "database",
+    "Run from a local checkout": "checkout",
+    "Optional: enable the Web UI": "webui",
+    "Optional: install the `agent-bus-workflows` skill": "workflow",
+}
+WEB_UI_SECTION_VARIANTS = {
+    "Start the Web UI": "start",
+    "Find a topic": "find",
+    "Open a thread": "thread",
+    "Search the bus": "search",
+    "Export a topic": "export",
+    "Troubleshooting": "troubleshooting",
+}
 
 
 @dataclass(frozen=True)
@@ -190,25 +213,28 @@ def relative_asset_href(target_rel: PurePosixPath, repo_rel: PurePosixPath) -> s
 
 
 def rewrite_html_images(text: str, source_rel: PurePosixPath, target_rel: PurePosixPath) -> str:
-    def replace(match: re.Match[str]) -> str:
+    def rewrite_attrs(
+        match: re.Match[str], tag_name: str, attr_name: str
+    ) -> str:
         attrs = ATTR_RE.findall(match.group(1))
         rewritten: list[tuple[str, str]] = []
-        src_found = False
+        target_found = False
         for key, value in attrs:
-            if key == "src":
+            if key == attr_name:
                 resolved = resolve_repo_rel(source_rel.parent, value)
                 if resolved:
                     relative = relative_asset_href(target_rel, resolved)
                     if relative:
                         value = relative
-                src_found = True
+                target_found = True
             rewritten.append((key, value))
-        if not src_found:
+        if not target_found:
             return match.group(0)
         rendered = " ".join(f'{key}="{value}"' for key, value in rewritten)
-        return f"<img {rendered} />"
+        return f"<{tag_name} {rendered} />"
 
-    return HTML_IMAGE_RE.sub(replace, text)
+    text = HTML_IMAGE_RE.sub(lambda match: rewrite_attrs(match, "img", "src"), text)
+    return HTML_SOURCE_RE.sub(lambda match: rewrite_attrs(match, "source", "srcset"), text)
 
 
 def rewrite_markdown_images(text: str, source_rel: PurePosixPath, target_rel: PurePosixPath) -> str:
@@ -249,6 +275,8 @@ def rewrite_markdown_links(
         target_route = route_path_for_generated_page(mapped)
         relative = posixpath.relpath(target_route or ".", start=current_route or ".")
         rewritten = "./" if relative == "." else relative
+        if rewritten != "./" and not rewritten.startswith((".", "/")):
+            rewritten = f"./{rewritten}"
         if not rewritten.endswith("/"):
             rewritten = f"{rewritten}/"
         if hash_sep:
@@ -271,6 +299,70 @@ def rewrite_content(
         return rewrite_markdown_links(segment, source_rel, target_rel, source_map)
 
     return replace_outside_code_fences(text, replacer)
+
+
+def apply_site_only_page_transforms(text: str, source_rel: PurePosixPath) -> str:
+    if source_rel == TUTORIAL_STEPS_PAGE:
+        text = wrap_tutorial_steps(text)
+    if source_rel == INSTALL_GUIDE_PAGE:
+        text = wrap_named_sections(text, "InstallSection", INSTALL_SECTION_VARIANTS)
+    if source_rel == WEB_UI_GUIDE_PAGE:
+        text = wrap_named_sections(text, "WebUiSection", WEB_UI_SECTION_VARIANTS)
+    return text
+
+
+def wrap_tutorial_steps(text: str) -> str:
+    start_marker = "## Step 1: connect Agent Bus in both clients"
+    end_marker = "## What you just learned"
+    start = text.find(start_marker)
+    end = text.find(end_marker)
+    if start == -1 or end == -1 or end <= start:
+        return text
+
+    before = text[:start].rstrip()
+    steps_block = text[start:end].strip()
+    after = text[end:].lstrip()
+    parts = re.split(r"(?m)(?=^## Step \d+: )", steps_block)
+    step_sections = [part.strip() for part in parts if part.strip()]
+    if not step_sections:
+        return text
+
+    wrapped_steps = "\n\n".join(
+        f'<div className="fd-step">\n\n{section}\n\n</div>' for section in step_sections
+    )
+    wrapped = f'<div className="fd-steps">\n\n{wrapped_steps}\n\n</div>'
+    return f"{before}\n\n{wrapped}\n\n{after}"
+
+
+def wrap_named_sections(
+    text: str, component_name: str, variant_map: dict[str, str]
+) -> str:
+    heading_matches = list(re.finditer(r"(?m)^## (.+)$", text))
+    if not heading_matches:
+        return text
+
+    result: list[str] = []
+    cursor = 0
+
+    for index, match in enumerate(heading_matches):
+        title = match.group(1).strip()
+        next_start = heading_matches[index + 1].start() if index + 1 < len(heading_matches) else len(text)
+        section = text[match.start() : next_start].strip()
+        result.append(text[cursor : match.start()])
+        cursor = next_start
+
+        variant = variant_map.get(title)
+        if variant:
+            result.append(
+                f'<{component_name} variant="{variant}">\n\n{section}\n\n</{component_name}>\n\n'
+            )
+        else:
+            result.append(section)
+            if next_start < len(text):
+                result.append("\n\n")
+
+    result.append(text[cursor:])
+    return "".join(result)
 
 
 def docs_target_for(source_rel: PurePosixPath) -> PurePosixPath:
@@ -360,6 +452,7 @@ def write_page(
     raw = source_path.read_text(encoding="utf-8")
     body = strip_leading_h1(raw)
     body = strip_leading_description_block(body, record.description)
+    body = apply_site_only_page_transforms(body, record.source_rel)
     rewritten = rewrite_content(body, record.source_rel, record.target_rel, source_map).rstrip()
     destination = content_root / record.target_rel
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -377,11 +470,12 @@ def build_records(
         source_path = repo_root / source_rel
         fallback_title = target_rel.stem.replace("-", " ").title()
         text = source_path.read_text(encoding="utf-8")
+        title = PAGE_TITLE_OVERRIDES.get(source_rel, extract_title(text, fallback_title))
         records.append(
             PageRecord(
                 source_rel=source_rel,
                 target_rel=target_rel,
-                title=extract_title(text, fallback_title),
+                title=title,
                 description=extract_description(text),
             )
         )

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -1,26 +1,26 @@
 import Link from "next/link";
 import { ParallaxHero } from "@/components/parallax-hero";
-import { docsRoute, withBasePath } from "@/lib/shared";
+import { docsHref, withBasePath } from "@/lib/shared";
 
 const sectionLinks = [
   {
     title: "Tutorials",
-    href: `${docsRoute}/tutorials/first-topic-between-two-peers`,
+    href: docsHref("tutorials/first-topic-between-two-peers"),
     description: "Walk through one complete two-agent handoff.",
   },
   {
     title: "How-to Guides",
-    href: `${docsRoute}/how-to/install-and-configure-agent-bus`,
+    href: docsHref("how-to/install-and-configure-agent-bus"),
     description: "Get Agent Bus running and complete common setup tasks.",
   },
   {
     title: "Reference",
-    href: `${docsRoute}/reference/runtime-reference`,
+    href: docsHref("reference/runtime-reference"),
     description: "Look up tool names, environment variables, commands, and exact behavior.",
   },
   {
     title: "FAQ",
-    href: `${docsRoute}/explanation/why-agent-bus`,
+    href: docsHref("explanation/why-agent-bus"),
     description: "Read the rationale, fit boundaries, and common questions.",
   },
 ];
@@ -34,9 +34,9 @@ export default function HomePage() {
         description="Agent Bus gives MCP-capable tools a shared SQLite-backed message bus. Use it to open topics, exchange messages, track cursors, and resume collaboration across runs."
         imageSrc={withBasePath("/home-hero/agent-bus-home-hero-v1.png")}
         actions={[
-          { href: docsRoute, label: "Open docs", kind: "primary" },
+          { href: docsHref(), label: "Open docs", kind: "primary" },
           {
-            href: `${docsRoute}/tutorials/first-topic-between-two-peers`,
+            href: docsHref("tutorials/first-topic-between-two-peers"),
             label: "Start tutorial",
             kind: "secondary",
           },
@@ -134,25 +134,25 @@ export default function HomePage() {
               </div>
               <div className="mt-3 space-y-2 text-sm">
                 <Link
-                  href={`${docsRoute}/how-to/install-and-configure-agent-bus`}
+                  href={docsHref("how-to/install-and-configure-agent-bus")}
                   className="block text-fd-foreground underline decoration-fd-border underline-offset-4 transition hover:text-fd-primary"
                 >
                   Install and configure Agent Bus
                 </Link>
                 <Link
-                  href={`${docsRoute}/tutorials/first-topic-between-two-peers`}
+                  href={docsHref("tutorials/first-topic-between-two-peers")}
                   className="block text-fd-foreground underline decoration-fd-border underline-offset-4 transition hover:text-fd-primary"
                 >
                   Walk through a first topic between two peers
                 </Link>
                 <Link
-                  href={`${docsRoute}/how-to/use-the-web-ui`}
+                  href={docsHref("how-to/use-the-web-ui")}
                   className="block text-fd-foreground underline decoration-fd-border underline-offset-4 transition hover:text-fd-primary"
                 >
                   Use the Agent Bus Web UI
                 </Link>
                 <Link
-                  href={`${docsRoute}/reference/runtime-reference`}
+                  href={docsHref("reference/runtime-reference")}
                   className="block text-fd-foreground underline decoration-fd-border underline-offset-4 transition hover:text-fd-primary"
                 >
                   Open the runtime reference

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -19,9 +19,9 @@ const sectionLinks = [
     description: "Look up tool names, environment variables, commands, and exact behavior.",
   },
   {
-    title: "Explanation",
+    title: "FAQ",
     href: `${docsRoute}/explanation/why-agent-bus`,
-    description: "Understand the topic model, local-first design, and system tradeoffs.",
+    description: "Read the rationale, fit boundaries, and common questions.",
   },
 ];
 
@@ -67,12 +67,12 @@ export default function HomePage() {
               Choose a path
             </div>
             <h2 className="max-w-3xl text-3xl font-semibold tracking-[-0.04em] text-fd-foreground md:text-4xl">
-              Start with the docs section that matches the job.
+              Dive into the docs by task.
             </h2>
             <p className="max-w-2xl text-lg leading-8 text-fd-muted-foreground">
               Use the tutorial for a first handoff, the how-to guides for setup and operations, the
-              reference pages for exact details, and the explanation docs when you want the system
-              rationale.
+              reference pages for exact details, and the FAQ when you want the system rationale and
+              boundaries.
             </p>
           </div>
 

--- a/site/src/app/global.css
+++ b/site/src/app/global.css
@@ -21,3 +21,18 @@ html > body[data-scroll-locked] {
   margin-right: 0 !important;
   --removed-body-scroll-bar-size: 0 !important;
 }
+
+article#nd-page .fd-steps {
+  margin-inline-start: 0.75rem;
+  padding-inline-start: 1.9rem;
+}
+
+article#nd-page .fd-step::before {
+  inline-size: 2.25rem;
+  block-size: 2.25rem;
+  inset-inline-start: -1.125rem;
+  border: 1.5px solid color-mix(in srgb, var(--color-fd-border) 88%, white 12%);
+  box-shadow: 0 0 0 3px var(--color-fd-background);
+  font-size: 0.95rem;
+  font-weight: 600;
+}

--- a/site/src/components/docs-front-door.tsx
+++ b/site/src/components/docs-front-door.tsx
@@ -7,6 +7,7 @@ import {
   ListChecks,
   ArrowRight,
 } from "lucide-react";
+import { docsHref } from "@/lib/shared";
 
 type DocsSectionKey = "tutorials" | "how-to" | "reference" | "explanation";
 
@@ -27,7 +28,7 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
     title: "Tutorial",
     subtitle: "walkthrough",
     blurb: "Start with one complete handoff from topic creation to reply.",
-    href: "/docs/tutorials/first-topic-between-two-peers",
+    href: docsHref("tutorials/first-topic-between-two-peers"),
     Icon: BookOpenText,
   },
   "how-to": {
@@ -36,7 +37,7 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
     title: "How-to",
     subtitle: "tasks",
     blurb: "Pick a concrete task and follow the shortest path to finish it.",
-    href: "/docs/how-to/install-and-configure-agent-bus",
+    href: docsHref("how-to/install-and-configure-agent-bus"),
     Icon: ListChecks,
   },
   reference: {
@@ -45,7 +46,7 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
     title: "Reference",
     subtitle: "facts",
     blurb: "Look up exact commands, tool names, config values, and behavior.",
-    href: "/docs/reference/runtime-reference",
+    href: docsHref("reference/runtime-reference"),
     Icon: FileSearch,
   },
   explanation: {
@@ -54,7 +55,7 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
     title: "FAQ",
     subtitle: "common questions",
     blurb: "Read the rationale, fit boundaries, and answers to common questions.",
-    href: "/docs/explanation/why-agent-bus",
+    href: docsHref("explanation/why-agent-bus"),
     Icon: Lightbulb,
   },
 };
@@ -135,7 +136,7 @@ export function DocsSectionIntro({ section }: { section: DocsSectionKey }) {
           </div>
         </div>
         <Link
-          href="/docs"
+          href={docsHref()}
           className="inline-flex items-center gap-2 text-sm font-medium text-fd-muted-foreground transition-colors hover:text-fd-primary"
         >
           Back to docs front door

--- a/site/src/components/docs-front-door.tsx
+++ b/site/src/components/docs-front-door.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import {
+  BookOpenText,
+  FileSearch,
+  Lightbulb,
+  ListChecks,
+  ArrowRight,
+} from "lucide-react";
+
+type DocsSectionKey = "tutorials" | "how-to" | "reference" | "explanation";
+
+type DocsSectionDef = {
+  key: DocsSectionKey;
+  order: string;
+  title: string;
+  subtitle: string;
+  blurb: string;
+  href: string;
+  Icon: LucideIcon;
+};
+
+const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
+  tutorials: {
+    key: "tutorials",
+    order: "01",
+    title: "Tutorial",
+    subtitle: "walkthrough",
+    blurb: "Start with one complete handoff from topic creation to reply.",
+    href: "/docs/tutorials/first-topic-between-two-peers",
+    Icon: BookOpenText,
+  },
+  "how-to": {
+    key: "how-to",
+    order: "02",
+    title: "How-to",
+    subtitle: "tasks",
+    blurb: "Pick a concrete task and follow the shortest path to finish it.",
+    href: "/docs/how-to/install-and-configure-agent-bus",
+    Icon: ListChecks,
+  },
+  reference: {
+    key: "reference",
+    order: "03",
+    title: "Reference",
+    subtitle: "facts",
+    blurb: "Look up exact commands, tool names, config values, and behavior.",
+    href: "/docs/reference/runtime-reference",
+    Icon: FileSearch,
+  },
+  explanation: {
+    key: "explanation",
+    order: "04",
+    title: "FAQ",
+    subtitle: "common questions",
+    blurb: "Read the rationale, fit boundaries, and answers to common questions.",
+    href: "/docs/explanation/why-agent-bus",
+    Icon: Lightbulb,
+  },
+};
+
+const SECTION_ORDER: DocsSectionKey[] = ["tutorials", "how-to", "reference", "explanation"];
+
+export function DocsFrontDoor() {
+  return (
+    <section className="mb-8 mt-7">
+      <div className="mb-4 border-b border-fd-border pb-3">
+        <p className="text-xs font-medium uppercase tracking-[0.24em] text-fd-muted-foreground">
+          Pick A Route
+        </p>
+        <p className="mt-2 max-w-2xl text-sm text-fd-muted-foreground">
+          Choose the section that matches the kind of help you need. Each card opens the best first
+          page for that route.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {SECTION_ORDER.map((key) => (
+          <DocsFrontDoorCard key={key} section={DOCS_SECTIONS[key]} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DocsFrontDoorCard({ section }: { section: DocsSectionDef }) {
+  const { Icon } = section;
+
+  return (
+    <Link
+      href={section.href}
+      className="group relative overflow-hidden rounded-2xl border border-fd-border bg-fd-card/65 p-5 transition-[transform,border-color,background-color,box-shadow] duration-150 hover:-translate-y-0.5 hover:border-fd-primary/35 hover:bg-fd-card hover:shadow-sm"
+    >
+      <div className="absolute right-4 top-4 text-sm font-medium tracking-[0.18em] text-fd-muted-foreground">
+        {section.order}
+      </div>
+      <div className="mb-5 inline-flex h-12 w-12 items-center justify-center rounded-xl border border-fd-border bg-fd-background/70 text-fd-foreground">
+        <Icon className="h-6 w-6" />
+      </div>
+      <div className="space-y-2">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight text-fd-foreground">
+            {section.title}
+          </h2>
+          <p className="mt-1 text-sm text-fd-muted-foreground">{section.subtitle}</p>
+        </div>
+        <div className="h-px w-full bg-fd-border" />
+        <p className="max-w-[28rem] text-sm leading-6 text-fd-muted-foreground">{section.blurb}</p>
+      </div>
+      <div className="mt-5 inline-flex items-center gap-2 text-sm font-medium text-fd-foreground/85 transition-colors group-hover:text-fd-primary">
+        Open section
+        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  );
+}
+
+export function DocsSectionIntro({ section }: { section: DocsSectionKey }) {
+  const meta = DOCS_SECTIONS[section];
+  const { Icon } = meta;
+
+  return (
+    <section className="mb-7 mt-7 overflow-hidden rounded-2xl border border-fd-border bg-fd-card/55">
+      <div className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-4">
+          <div className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-fd-border bg-fd-background/70 text-fd-foreground">
+            <Icon className="h-6 w-6" />
+          </div>
+          <div>
+            <div className="text-xs font-medium uppercase tracking-[0.22em] text-fd-muted-foreground">
+              {meta.order} {meta.title}
+            </div>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-fd-muted-foreground">
+              {meta.blurb}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/docs"
+          className="inline-flex items-center gap-2 text-sm font-medium text-fd-muted-foreground transition-colors hover:text-fd-primary"
+        >
+          Back to docs front door
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export function getDocsSection(path: string): DocsSectionKey | null {
+  const [firstSegment] = path.split("/");
+  if (firstSegment === "tutorials" || firstSegment === "how-to" || firstSegment === "reference" || firstSegment === "explanation") {
+    return firstSegment;
+  }
+  return null;
+}

--- a/site/src/components/docs-page-boards.tsx
+++ b/site/src/components/docs-page-boards.tsx
@@ -111,7 +111,7 @@ function DocsActionCard({ card }: { card: BoardCard }) {
         {card.order}
       </div>
       <div className="mb-5 inline-flex h-11 w-11 items-center justify-center rounded-xl border border-fd-border bg-fd-background/70 text-fd-foreground">
-        <Icon className="h-5.5 w-5.5" />
+        <Icon className="h-[22px] w-[22px]" />
       </div>
       <div className="space-y-2">
         <div>

--- a/site/src/components/docs-page-boards.tsx
+++ b/site/src/components/docs-page-boards.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowRight,
+  Clock3,
+  HardDrive,
+  MessageCircle,
+  MessageSquare,
+  Route,
+  Users,
+} from "lucide-react";
+
+type BoardCard = {
+  order: string;
+  title: string;
+  subtitle: string;
+  href: string;
+  Icon: LucideIcon;
+};
+
+const WHY_AGENT_BUS_CARDS: BoardCard[] = [
+  {
+    order: "01",
+    title: "Topics",
+    subtitle: "replace implicit threads",
+    href: "#topics-instead-of-implicit-threads",
+    Icon: MessageSquare,
+  },
+  {
+    order: "02",
+    title: "Stable peers",
+    subtitle: "keep names meaningful",
+    href: "#stable-peer-identity",
+    Icon: Users,
+  },
+  {
+    order: "03",
+    title: "Server cursors",
+    subtitle: "resume without client checkpoints",
+    href: "#server-side-cursors",
+    Icon: Clock3,
+  },
+  {
+    order: "04",
+    title: "Local surface",
+    subtitle: "stdio, SQLite, optional UI",
+    href: "#one-local-dependency-surface",
+    Icon: HardDrive,
+  },
+  {
+    order: "05",
+    title: "Where it fits",
+    subtitle: "strong for local coordination",
+    href: "#where-agent-bus-fits",
+    Icon: Route,
+  },
+  {
+    order: "06",
+    title: "Why not chat",
+    subtitle: "conversation is not enough",
+    href: "#why-not-just-use-chat",
+    Icon: MessageCircle,
+  },
+];
+
+export function WhyAgentBusBoard() {
+  return (
+    <DocsActionBoard
+      eyebrow="Design Map"
+      description="The core idea is simple: coordination works better when topics, peers, cursors, and fit boundaries are explicit."
+      cards={WHY_AGENT_BUS_CARDS}
+    />
+  );
+}
+
+function DocsActionBoard({
+  eyebrow,
+  description,
+  cards,
+}: {
+  eyebrow: string;
+  description: string;
+  cards: BoardCard[];
+}) {
+  return (
+    <section className="mb-8 mt-7">
+      <div className="mb-4 border-b border-fd-border pb-3">
+        <p className="text-xs font-medium uppercase tracking-[0.24em] text-fd-muted-foreground">
+          {eyebrow}
+        </p>
+        <p className="mt-2 max-w-2xl text-sm text-fd-muted-foreground">{description}</p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {cards.map((card) => (
+          <DocsActionCard key={card.href} card={card} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DocsActionCard({ card }: { card: BoardCard }) {
+  const { Icon } = card;
+
+  return (
+    <Link
+      href={card.href}
+      className="group relative overflow-hidden rounded-2xl border border-fd-border bg-fd-card/55 p-5 transition-[transform,border-color,background-color,box-shadow] duration-150 hover:-translate-y-0.5 hover:border-fd-primary/35 hover:bg-fd-card hover:shadow-sm"
+    >
+      <div className="absolute right-4 top-4 text-sm font-medium tracking-[0.18em] text-fd-muted-foreground">
+        {card.order}
+      </div>
+      <div className="mb-5 inline-flex h-11 w-11 items-center justify-center rounded-xl border border-fd-border bg-fd-background/70 text-fd-foreground">
+        <Icon className="h-5.5 w-5.5" />
+      </div>
+      <div className="space-y-2">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight text-fd-foreground">{card.title}</h2>
+          <p className="mt-1 text-sm text-fd-muted-foreground">{card.subtitle}</p>
+        </div>
+        <div className="h-px w-full bg-fd-border" />
+      </div>
+      <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-fd-foreground/80 transition-colors group-hover:text-fd-primary">
+        Jump to section
+        <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  );
+}

--- a/site/src/components/install-section.tsx
+++ b/site/src/components/install-section.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Boxes,
+  Database,
+  Download,
+  LayoutPanelTop,
+  MessageSquare,
+  Play,
+  Search,
+  Settings2,
+  Sparkles,
+  SquareTerminal,
+  TriangleAlert,
+} from "lucide-react";
+
+type InstallSectionVariant =
+  | "package"
+  | "client"
+  | "database"
+  | "checkout"
+  | "webui"
+  | "workflow";
+
+type WebUiSectionVariant =
+  | "start"
+  | "find"
+  | "thread"
+  | "search"
+  | "export"
+  | "troubleshooting";
+
+type InstallSectionMeta = {
+  kicker: string;
+  Icon: LucideIcon;
+};
+
+const SECTION_META: Record<InstallSectionVariant | WebUiSectionVariant, InstallSectionMeta> = {
+  package: {
+    kicker: "Published package",
+    Icon: Boxes,
+  },
+  client: {
+    kicker: "Client setup",
+    Icon: Settings2,
+  },
+  database: {
+    kicker: "Shared database",
+    Icon: Database,
+  },
+  checkout: {
+    kicker: "Local checkout",
+    Icon: SquareTerminal,
+  },
+  webui: {
+    kicker: "Web UI",
+    Icon: LayoutPanelTop,
+  },
+  workflow: {
+    kicker: "Workflow skill",
+    Icon: Sparkles,
+  },
+  start: {
+    kicker: "Start the server",
+    Icon: Play,
+  },
+  find: {
+    kicker: "Find a topic",
+    Icon: Search,
+  },
+  thread: {
+    kicker: "Thread view",
+    Icon: MessageSquare,
+  },
+  search: {
+    kicker: "Search",
+    Icon: Search,
+  },
+  export: {
+    kicker: "Export",
+    Icon: Download,
+  },
+  troubleshooting: {
+    kicker: "Troubleshooting",
+    Icon: TriangleAlert,
+  },
+};
+
+export function InstallSection({
+  variant,
+  children,
+}: {
+  variant: InstallSectionVariant;
+  children: ReactNode;
+}) {
+  return <GuideSection variant={variant}>{children}</GuideSection>;
+}
+
+export function WebUiSection({
+  variant,
+  children,
+}: {
+  variant: WebUiSectionVariant;
+  children: ReactNode;
+}) {
+  return <GuideSection variant={variant}>{children}</GuideSection>;
+}
+
+function GuideSection({
+  variant,
+  children,
+}: {
+  variant: InstallSectionVariant | WebUiSectionVariant;
+  children: ReactNode;
+}) {
+  const { Icon, kicker } = SECTION_META[variant];
+  return (
+    <section className="my-8 rounded-2xl border border-fd-border bg-fd-card/45 px-5 py-5 sm:px-6">
+      <div className="flex items-start gap-4">
+        <div className="mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-fd-border bg-fd-background/75 text-fd-foreground">
+          <Icon className="h-5.5 w-5.5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="mb-2 text-xs font-medium uppercase tracking-[0.22em] text-fd-muted-foreground">
+            {kicker}
+          </p>
+          <div className="[&>h2]:mt-0 [&>h2]:border-none [&>h2]:pb-0 [&>h2]:text-3xl [&>h2]:font-semibold [&>h2]:tracking-tight [&>p:first-of-type]:mt-2">
+            {children}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/install-section.tsx
+++ b/site/src/components/install-section.tsx
@@ -61,7 +61,7 @@ const SECTION_META: Record<InstallSectionVariant | WebUiSectionVariant, InstallS
     Icon: Sparkles,
   },
   start: {
-    kicker: "Start the server",
+    kicker: "Start the Web UI",
     Icon: Play,
   },
   find: {

--- a/site/src/components/install-section.tsx
+++ b/site/src/components/install-section.tsx
@@ -118,7 +118,7 @@ function GuideSection({
     <section className="my-8 rounded-2xl border border-fd-border bg-fd-card/45 px-5 py-5 sm:px-6">
       <div className="flex items-start gap-4">
         <div className="mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-fd-border bg-fd-background/75 text-fd-foreground">
-          <Icon className="h-5.5 w-5.5" />
+          <Icon className="h-[22px] w-[22px]" />
         </div>
         <div className="min-w-0 flex-1">
           <p className="mb-2 text-xs font-medium uppercase tracking-[0.22em] text-fd-muted-foreground">

--- a/site/src/components/mdx.tsx
+++ b/site/src/components/mdx.tsx
@@ -1,4 +1,5 @@
 import { DocsImage } from "@/components/docs";
+import { InstallSection, WebUiSection } from "@/components/install-section";
 import { TopicFlowDiagram } from "@/components/topic-flow-diagram";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
@@ -7,6 +8,8 @@ export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
     img: DocsImage,
+    InstallSection,
+    WebUiSection,
     TopicFlowDiagram,
     ...components,
   } satisfies MDXComponents;

--- a/site/src/lib/docs-page.tsx
+++ b/site/src/lib/docs-page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { DocsFrontDoor, DocsSectionIntro, getDocsSection } from "@/components/docs-front-door";
+import { WhyAgentBusBoard } from "@/components/docs-page-boards";
 import { getMDXComponents } from "@/components/mdx";
 import { getPageImage, getPageMarkdownUrl, getSourceRepoPath, source } from "@/lib/source";
 import { gitConfig } from "@/lib/shared";
@@ -26,6 +28,9 @@ export function renderDocsPage(page: DocsSourcePage) {
   const MDX = page.data.body;
   const markdownUrl = getPageMarkdownUrl(page).url;
   const sourceRepoPath = getSourceRepoPath(page);
+  const docsSection = getDocsSection(page.path);
+  const isDocsLanding = page.path === "index.mdx";
+  const pageBoard = getPageBoard(page.path);
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
@@ -38,11 +43,23 @@ export function renderDocsPage(page: DocsSourcePage) {
           githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/${sourceRepoPath}`}
         />
       </div>
+      {isDocsLanding ? <DocsFrontDoor /> : null}
+      {!isDocsLanding && docsSection ? <DocsSectionIntro section={docsSection} /> : null}
+      {pageBoard}
       <DocsBody>
         <MDX components={getMDXComponents()} />
       </DocsBody>
     </DocsPage>
   );
+}
+
+function getPageBoard(path: string) {
+  switch (path) {
+    case "explanation/why-agent-bus.mdx":
+      return <WhyAgentBusBoard />;
+    default:
+      return null;
+  }
 }
 
 export function buildDocsMetadata(page: DocsSourcePage): Metadata {

--- a/site/src/lib/shared.ts
+++ b/site/src/lib/shared.ts
@@ -26,5 +26,5 @@ export function docsHref(path = "") {
   if (!path) {
     return `${docsRoute}/`;
   }
-  return `${docsRoute}/${path.replace(/^\/+/, "")}`;
+  return `${docsRoute}/${path.replace(/^\/+/, "")}/`;
 }

--- a/site/src/lib/shared.ts
+++ b/site/src/lib/shared.ts
@@ -21,3 +21,10 @@ export function withBasePath(path: string) {
   }
   return `${basePath}${path}`;
 }
+
+export function docsHref(path = "") {
+  if (!path) {
+    return `${docsRoute}/`;
+  }
+  return `${docsRoute}/${path.replace(/^\/+/, "")}`;
+}

--- a/tests/test_generate_fumadocs_site.py
+++ b/tests/test_generate_fumadocs_site.py
@@ -93,26 +93,32 @@ Fast paths for concrete tasks.
 Install the package and start the server.
 
 ## Fastest path: run the published package with `uvx`
+<!-- site-wrap: package -->
 
 Fastest path body.
 
 ## Add Agent Bus to a client
+<!-- site-wrap: client -->
 
 Client setup body.
 
-## Share the same database between clients
+## Use one database path across clients
+<!-- site-wrap: database -->
 
 Shared database body.
 
-## Run from a local checkout
+## Work from a local checkout
+<!-- site-wrap: checkout -->
 
 Local checkout body.
 
-## Optional: enable the Web UI
+## Optional: turn on the Web UI
+<!-- site-wrap: webui -->
 
 Web UI body.
 
-## Optional: install the `agent-bus-workflows` skill
+## Optional: add the `agent-bus-workflows` skill
+<!-- site-wrap: workflow -->
 
 Workflow body.
 """,
@@ -127,27 +133,33 @@ Browse topics from the browser.
   <img src="../images/webui-overview.png" alt="Overview" width="960" />
 </p>
 
-## Start the Web UI
+## Launch the browser workbench
+<!-- site-wrap: start -->
 
 Start body.
 
-## Find a topic
+## Find a topic fast
+<!-- site-wrap: find -->
 
 Find body.
 
-## Open a thread
+## Open one thread
+<!-- site-wrap: thread -->
 
 Open body.
 
-## Search the bus
+## Search everything
+<!-- site-wrap: search -->
 
 Search body.
 
-## Export a topic
+## Export one topic
+<!-- site-wrap: export -->
 
 Export body.
 
-## Troubleshooting
+## Fix common problems
+<!-- site-wrap: troubleshooting -->
 
 Troubleshooting body.
 

--- a/tests/test_generate_fumadocs_site.py
+++ b/tests/test_generate_fumadocs_site.py
@@ -43,6 +43,7 @@ Welcome to the docs front door.
 - [How-to guides](how-to/README.md)
 - [Reference](reference/README.md)
 - [Explanation](explanation/README.md)
+- [Search and embeddings reference](reference/search-and-embeddings-reference.md)
 """,
     )
     _write(
@@ -59,6 +60,18 @@ Learn by doing.
         """# First topic between two peers
 
 Follow this guide to complete a basic handoff.
+
+## Step 1: connect Agent Bus in both clients
+
+Connect both clients.
+
+## Step 2: create a topic from the first agent
+
+Create the topic.
+
+## What you just learned
+
+Tutorial wrap-up.
 
 See [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md).
 """,
@@ -78,6 +91,30 @@ Fast paths for concrete tasks.
         """# Install and configure Agent Bus
 
 Install the package and start the server.
+
+## Fastest path: run the published package with `uvx`
+
+Fastest path body.
+
+## Add Agent Bus to a client
+
+Client setup body.
+
+## Share the same database between clients
+
+Shared database body.
+
+## Run from a local checkout
+
+Local checkout body.
+
+## Optional: enable the Web UI
+
+Web UI body.
+
+## Optional: install the `agent-bus-workflows` skill
+
+Workflow body.
 """,
     )
     _write(
@@ -89,6 +126,30 @@ Browse topics from the browser.
 <p align="center">
   <img src="../images/webui-overview.png" alt="Overview" width="960" />
 </p>
+
+## Start the Web UI
+
+Start body.
+
+## Find a topic
+
+Find body.
+
+## Open a thread
+
+Open body.
+
+## Search the bus
+
+Search body.
+
+## Export a topic
+
+Export body.
+
+## Troubleshooting
+
+Troubleshooting body.
 
 See [Runtime reference](../reference/runtime-reference.md).
 """,
@@ -112,6 +173,13 @@ Lookup commands and configuration values.
 
 - [Implementation spec](../../spec.md)
 - [Changelog](../../CHANGELOG.md)
+""",
+    )
+    _write(
+        repo_root / "docs" / "reference" / "search-and-embeddings-reference.md",
+        """# Search and embeddings reference
+
+Exact search and indexing details.
 """,
     )
     _write(
@@ -146,12 +214,35 @@ Understand the local-only design.
 
     how_to_page = (content_root / "how-to" / "use-the-web-ui.mdx").read_text(encoding="utf-8")
     root_page = (content_root / "index.mdx").read_text(encoding="utf-8")
+    install_page = (content_root / "how-to" / "install-and-configure-agent-bus.mdx").read_text(
+        encoding="utf-8"
+    )
+    tutorial_page = (content_root / "tutorials" / "first-topic-between-two-peers.mdx").read_text(
+        encoding="utf-8"
+    )
     assert "../../../docs-assets/images/webui-overview.png" in how_to_page
+    assert '<WebUiSection variant="start">' in how_to_page
+    assert '<WebUiSection variant="find">' in how_to_page
+    assert '<WebUiSection variant="thread">' in how_to_page
+    assert '<WebUiSection variant="search">' in how_to_page
+    assert '<WebUiSection variant="export">' in how_to_page
+    assert '<WebUiSection variant="troubleshooting">' in how_to_page
+    assert '<InstallSection variant="package">' in install_page
+    assert '<InstallSection variant="client">' in install_page
+    assert '<InstallSection variant="database">' in install_page
+    assert '<InstallSection variant="checkout">' in install_page
+    assert '<InstallSection variant="webui">' in install_page
+    assert '<InstallSection variant="workflow">' in install_page
+    assert '<div className="fd-steps">' in tutorial_page
+    assert tutorial_page.count('<div className="fd-step">') >= 2
+    assert "## Step 1: connect Agent Bus in both clients" in tutorial_page
+    assert "## What you just learned" in tutorial_page
     assert "../../reference/runtime-reference/" in how_to_page
-    assert "tutorials/first-topic-between-two-peers/" in root_page
-    assert "how-to/install-and-configure-agent-bus/" in root_page
-    assert "reference/runtime-reference/" in root_page
-    assert "explanation/why-agent-bus/" in root_page
+    assert "./tutorials/first-topic-between-two-peers/" in root_page
+    assert "./how-to/install-and-configure-agent-bus/" in root_page
+    assert "./reference/runtime-reference/" in root_page
+    assert "./reference/search-and-embeddings-reference/" in root_page
+    assert "./explanation/why-agent-bus/" in root_page
     assert ".mdx" not in root_page
     assert ".mdx" not in how_to_page
     assert root_page.count("Welcome to the docs front door.") == 1
@@ -174,6 +265,7 @@ Understand the local-only design.
         "runtime-reference",
         "implementation-spec",
         "changelog",
+        "search-and-embeddings-reference",
     ]
     assert (public_root / "docs-assets" / "images" / "webui-overview.png").exists()
 


### PR DESCRIPTION
## Summary
- replace the docs landing and section intro infographics on the site with native Fumadocs cards and section callouts
- add a dedicated search and embeddings reference page and split that material out of the runtime reference
- wrap the tutorial and how-to content in site-native components during Fumadocs generation, and fix docs-root link rewriting for /docs without a trailing slash

## Testing
- uv run ruff check
- uv run ty check
- uv run pytest
- pnpm --dir frontend build
- pnpm --dir site types:check
- GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp pnpm --dir site build