### PR TITLE
fix(web): resync topic pages after live deletions

### DIFF
--- a/frontend/public/app-mark.svg
+++ b/frontend/public/app-mark.svg
@@ -2,64 +2,74 @@
   <style>
     .guide {
       stroke: #707887;
-      stroke-opacity: 0.18;
+      stroke-opacity: 0.12;
       stroke-width: 1;
       stroke-dasharray: 4 8;
     }
 
-    .frame {
+    .spoke-soft {
       fill: none;
-      stroke: #465062;
-      stroke-width: 1.5;
+      stroke: #667186;
+      stroke-opacity: 0.16;
+      stroke-width: 8;
       stroke-linecap: round;
       stroke-linejoin: round;
     }
 
-    .trace {
+    .spoke {
       fill: none;
       stroke: #d9deea;
-      stroke-width: 2.6;
+      stroke-width: 2.35;
       stroke-linecap: round;
       stroke-linejoin: round;
     }
 
-    .trace-muted {
-      fill: none;
-      stroke: #aab1bf;
-      stroke-opacity: 0.76;
-      stroke-width: 2.2;
-      stroke-linecap: round;
-      stroke-linejoin: round;
+    .accent {
+      fill: rgba(145, 167, 255, 0.16);
+      stroke: #dfe5ff;
+      stroke-width: 1.3;
     }
 
-    .node {
-      fill: #1f2229;
+    .port {
+      fill: #20242c;
       stroke: #d9deea;
-      stroke-width: 2.2;
+      stroke-width: 1.9;
     }
 
-    .cursor {
+    .hub {
       fill: none;
-      stroke: #c6cedd;
-      stroke-width: 2.1;
+      stroke: #bcc5d5;
+      stroke-opacity: 0.72;
+      stroke-width: 1.55;
+    }
+
+    .hub-core {
+      fill: #edf1fb;
+    }
+
+    .measure {
+      fill: none;
+      stroke: #616b7d;
+      stroke-opacity: 0.54;
+      stroke-width: 1.05;
       stroke-linecap: round;
     }
 
     .token {
-      fill: #a9b8ff;
-      stroke: #dfe5ff;
-      stroke-width: 1.2;
+      fill: #aab8ff;
+      stroke: #e4e9ff;
+      stroke-width: 1.1;
     }
 
     .token-core {
-      fill: #dfe5ff;
-      opacity: 0.78;
+      fill: #f1f4ff;
+      opacity: 0.84;
     }
 
-    .pulse {
+    .halo {
       fill: none;
-      stroke: #9aaafd;
-      stroke-width: 1.5;
+      stroke: #9fb0ff;
+      stroke-width: 1.35;
       opacity: 0;
     }
 
@@ -78,52 +88,191 @@
     }
   </style>
 
-  <path class="guide" d="M18 75H242" />
-  <path class="guide" d="M32 18V132" />
-  <path class="guide" d="M126 18V132" />
-  <path class="guide" d="M228 18V132" />
+  <path class="guide" d="M24 75H236" />
+  <path class="guide" d="M54 18V132" />
+  <path class="guide" d="M130 18V132" />
+  <path class="guide" d="M206 18V132" />
 
-  <rect class="frame" x="22" y="32" width="90" height="18" rx="9" />
-  <rect class="frame" x="22" y="66" width="64" height="18" rx="9" />
-  <rect class="frame" x="22" y="100" width="76" height="18" rx="9" />
+  <path class="spoke-soft" d="M54 108L130 75" />
+  <path class="spoke-soft" d="M206 108L130 75" />
+  <path class="spoke-soft" d="M130 30L130 75" />
 
-  <path class="trace-muted" d="M112 41H126" />
-  <path class="trace" d="M86 75H126H180" />
-  <path class="trace-muted" d="M98 109H126" />
-  <path class="trace-muted" d="M126 41V109" />
+  <path class="spoke" d="M54 108L130 75" />
+  <path class="spoke" d="M206 108L130 75" />
+  <path class="spoke" d="M130 30L130 75" />
 
-  <circle class="node" cx="126" cy="41" r="4.8" />
-  <circle class="node" cx="126" cy="75" r="5.4" />
-  <circle class="node" cx="126" cy="109" r="4.8" />
+  <rect class="accent" x="157" y="86" width="22" height="12" rx="6" transform="rotate(23.5 168 92)" />
+  <rect class="accent" x="136" y="44" width="18" height="10" rx="5" />
 
-  <rect class="frame" x="180" y="44" width="56" height="62" rx="16" />
-  <path class="cursor" d="M196 60H216" />
-  <path class="cursor" d="M196 75H210" />
-  <path class="cursor" d="M196 90H214" />
-  <circle class="node" cx="218" cy="75" r="4.6" />
+  <line class="measure" x1="130" y1="22" x2="130" y2="16" />
+  <line class="measure" x1="130" y1="128" x2="130" y2="134" />
+  <line class="measure" x1="40" y1="108" x2="32" y2="108" />
+  <line class="measure" x1="220" y1="108" x2="228" y2="108" />
+  <path class="measure" d="M64 118H196" />
+  <line class="measure" x1="100" y1="114" x2="100" y2="122" />
+  <line class="measure" x1="160" y1="114" x2="160" y2="122" />
+
+  <circle class="hub" cx="130" cy="75" r="12" />
+  <circle class="hub-core" cx="130" cy="75" r="4" />
+
+  <circle class="port" cx="54" cy="108" r="5" />
+  <circle class="port" cx="206" cy="108" r="5" />
+  <circle class="port" cx="130" cy="30" r="5" />
 
   <g class="motion">
-    <rect class="token" x="-6" y="-6" width="12" height="12" rx="3">
-      <animateMotion dur="3.8s" repeatCount="indefinite" path="M50 75H218" keyTimes="0;0.7;1" keySplines="0.2 0 0.2 1;0.2 0 0.2 1" calcMode="spline" />
-      <animate attributeName="opacity" values="0;1;1;1;0" keyTimes="0;0.08;0.78;0.92;1" dur="3.8s" repeatCount="indefinite" />
-    </rect>
-    <rect class="token-core" x="-2" y="-2" width="4" height="4" rx="1">
-      <animateMotion dur="3.8s" repeatCount="indefinite" path="M50 75H218" keyTimes="0;0.7;1" keySplines="0.2 0 0.2 1;0.2 0 0.2 1" calcMode="spline" />
-      <animate attributeName="opacity" values="0;0.7;0.7;0.7;0" keyTimes="0;0.08;0.78;0.92;1" dur="3.8s" repeatCount="indefinite" />
+    <rect class="token" x="-5" y="-5" width="10" height="10" rx="2.5">
+      <animateMotion
+        dur="3.9s"
+        repeatCount="indefinite"
+        path="M54 108L130 75L130 30"
+        keyTimes="0;0.58;1"
+        keySplines="0.2 0 0.2 1;0.2 0 0.2 1"
+        calcMode="spline"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;1;1;1;0"
+        keyTimes="0;0.06;0.74;0.92;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+      />
     </rect>
 
-    <circle class="pulse" cx="218" cy="75" r="7">
-      <animate attributeName="r" values="7;7;7;7;19" keyTimes="0;0.76;0.83;0.9;1" dur="3.8s" repeatCount="indefinite" />
-      <animate attributeName="opacity" values="0;0;0;0.85;0" keyTimes="0;0.76;0.83;0.9;1" dur="3.8s" repeatCount="indefinite" />
+    <rect class="token-core" x="-1.5" y="-1.5" width="3" height="3" rx="0.8">
+      <animateMotion
+        dur="3.9s"
+        repeatCount="indefinite"
+        path="M54 108L130 75L130 30"
+        keyTimes="0;0.58;1"
+        keySplines="0.2 0 0.2 1;0.2 0 0.2 1"
+        calcMode="spline"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;0.84;0.84;0.84;0"
+        keyTimes="0;0.06;0.74;0.92;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+      />
+    </rect>
+
+    <rect class="token" x="-5" y="-5" width="10" height="10" rx="2.5">
+      <animateMotion
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+        path="M206 108L130 75L54 108"
+        keyTimes="0;0.5;1"
+        keySplines="0.2 0 0.2 1;0.2 0 0.2 1"
+        calcMode="spline"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;1;1;1;0"
+        keyTimes="0;0.06;0.74;0.92;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+      />
+    </rect>
+
+    <rect class="token-core" x="-1.5" y="-1.5" width="3" height="3" rx="0.8">
+      <animateMotion
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+        path="M206 108L130 75L54 108"
+        keyTimes="0;0.5;1"
+        keySplines="0.2 0 0.2 1;0.2 0 0.2 1"
+        calcMode="spline"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;0.84;0.84;0.84;0"
+        keyTimes="0;0.06;0.74;0.92;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+      />
+    </rect>
+
+    <circle class="halo" cx="130" cy="75" r="6">
+      <animate
+        attributeName="r"
+        values="6;6;6;18;18"
+        keyTimes="0;0.52;0.60;0.74;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;0;0.72;0;0"
+        keyTimes="0;0.52;0.60;0.74;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+      />
     </circle>
-    <circle class="pulse" cx="218" cy="75" r="7">
-      <animate attributeName="r" values="7;7;7;7;24" keyTimes="0;0.8;0.86;0.94;1" dur="3.8s" repeatCount="indefinite" />
-      <animate attributeName="opacity" values="0;0;0;0.45;0" keyTimes="0;0.8;0.86;0.94;1" dur="3.8s" repeatCount="indefinite" />
+
+    <circle class="halo" cx="130" cy="75" r="6">
+      <animate
+        attributeName="r"
+        values="6;6;6;18;18"
+        keyTimes="0;0.34;0.42;0.58;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;0;0.72;0;0"
+        keyTimes="0;0.34;0.42;0.58;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+      />
+    </circle>
+
+    <circle class="halo" cx="130" cy="30" r="6">
+      <animate
+        attributeName="r"
+        values="6;6;6;16"
+        keyTimes="0;0.88;0.94;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;0;0.72;0"
+        keyTimes="0;0.88;0.94;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+      />
+    </circle>
+
+    <circle class="halo" cx="54" cy="108" r="6">
+      <animate
+        attributeName="r"
+        values="6;6;6;16"
+        keyTimes="0;0.88;0.94;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+      />
+      <animate
+        attributeName="opacity"
+        values="0;0;0.72;0"
+        keyTimes="0;0.88;0.94;1"
+        dur="3.9s"
+        repeatCount="indefinite"
+        begin="1.65s"
+      />
     </circle>
   </g>
 
   <g class="motion-reduced">
-    <rect class="token" x="212" y="69" width="12" height="12" rx="3" />
-    <rect class="token-core" x="216" y="73" width="4" height="4" rx="1" />
+    <rect class="token" x="125" y="70" width="10" height="10" rx="2.5" />
+    <rect class="token-core" x="128.5" y="73.5" width="3" height="3" rx="0.8" />
+    <rect class="token" x="49" y="103" width="10" height="10" rx="2.5" />
+    <rect class="token-core" x="52.5" y="106.5" width="3" height="3" rx="0.8" />
   </g>
 </svg>

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -537,4 +537,181 @@ describe("App", () => {
       fetchSpy.mock.calls.filter(([input]) => String(input) === "/api/topics/t-1")
     ).toHaveLength(2)
   })
+
+  test("refetches full topic detail when last_seq advances without message_count growth", async () => {
+    let currentDetail: TopicDetailResponse = topicDetail("t-1", "hello from alpha")
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(currentDetail)
+      }
+      if (url.pathname === "/api/topics/t-1/messages") {
+        return jsonResponse({
+          messages: [],
+          first_seq: null,
+          last_seq: null,
+          has_earlier: false,
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    currentDetail = {
+      ...currentDetail,
+      messages: [
+        {
+          message_id: "t-1-m-2",
+          topic_id: "t-1",
+          seq: 2,
+          sender: "reviewer",
+          message_type: "message",
+          reply_to: null,
+          reply_to_sender: null,
+          content_markdown: "replacement message",
+          metadata: null,
+          client_message_id: null,
+          created_at: 1_700_000_200,
+        },
+      ],
+      first_seq: 2,
+      last_seq: 2,
+      message_count: 1,
+      topic: {
+        ...currentDetail.topic,
+        last_seq: 2,
+        message_count: 1,
+        last_message_at: 1_700_000_200,
+        last_updated_at: 1_700_000_200,
+      },
+    }
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 2,
+      message_count: 1,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "replacement reviewer",
+          last_seq: 2,
+          updated_at: 1_700_000_210,
+        },
+      ],
+    })
+
+    expect(await screen.findByText("replacement message")).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText("hello from alpha")).not.toBeInTheDocument())
+    expect(
+      fetchSpy.mock.calls.filter(([input]) =>
+        String(input).includes("/api/topics/t-1/messages")
+      )
+    ).toHaveLength(0)
+  })
+
+  test("ignores stale refresh results after a newer topic update lands", async () => {
+    let detailRequestCount = 0
+    let resolveStaleRefresh!: (response: Response) => void
+    const staleRefresh = new Promise<Response>((resolve) => {
+      resolveStaleRefresh = resolve
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        detailRequestCount += 1
+        if (detailRequestCount === 1) {
+          return jsonResponse(topicDetail("t-1", "hello from alpha"))
+        }
+        if (detailRequestCount === 2) {
+          return staleRefresh
+        }
+      }
+      if (url.pathname === "/api/topics/t-1/messages" && url.searchParams.get("after_seq") === "1") {
+        return jsonResponse({
+          messages: [
+            {
+              message_id: "t-1-m-2",
+              topic_id: "t-1",
+              seq: 2,
+              sender: "reviewer",
+              message_type: "message",
+              reply_to: null,
+              reply_to_sender: null,
+              content_markdown: "message 2",
+              metadata: null,
+              client_message_id: null,
+              created_at: 1_700_000_220,
+            },
+          ],
+          first_seq: 2,
+          last_seq: 2,
+          has_earlier: false,
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 0,
+      message_count: 0,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "stale reviewer",
+          last_seq: 0,
+          updated_at: 1_700_000_230,
+        },
+      ],
+    })
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 2,
+      message_count: 2,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "fresh reviewer",
+          last_seq: 2,
+          updated_at: 1_700_000_240,
+        },
+      ],
+    })
+
+    expect(await screen.findByText("message 2")).toBeInTheDocument()
+
+    resolveStaleRefresh(
+      new Response(JSON.stringify(topicDetail("t-1", "stale detail")), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )
+
+    await waitFor(() => expect(screen.queryByText("stale detail")).not.toBeInTheDocument())
+    expect(screen.getByText("message 2")).toBeInTheDocument()
+    expect(
+      fetchSpy.mock.calls.filter(([input]) =>
+        String(input).includes("/api/topics/t-1/messages")
+      )
+    ).toHaveLength(1)
+  })
 })

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { MemoryRouter } from "react-router-dom"
+import { MemoryRouter, useNavigate } from "react-router-dom"
 import { describe, expect, test, vi } from "vitest"
 
 import App from "@/App"
@@ -131,6 +131,27 @@ function renderApp(initialEntries: string[]) {
   return render(
     <TooltipProvider>
       <MemoryRouter initialEntries={initialEntries}>
+        <App />
+      </MemoryRouter>
+    </TooltipProvider>
+  )
+}
+
+function renderAppWithControls(initialEntries: string[]) {
+  function NavigationControls() {
+    const navigate = useNavigate()
+
+    return (
+      <button type="button" onClick={() => navigate("/topics/t-1?focus=focused-message")}>
+        Focus same topic
+      </button>
+    )
+  }
+
+  return render(
+    <TooltipProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <NavigationControls />
         <App />
       </MemoryRouter>
     </TooltipProvider>
@@ -713,5 +734,67 @@ describe("App", () => {
         String(input).includes("/api/topics/t-1/messages")
       )
     ).toHaveLength(1)
+  })
+
+  test("ignores stale stream refreshes after the topic focus changes", async () => {
+    let detailRequestCount = 0
+    let resolveStaleRefresh!: (response: Response) => void
+    const staleRefresh = new Promise<Response>((resolve) => {
+      resolveStaleRefresh = resolve
+    })
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1" && url.searchParams.get("focus") === "focused-message") {
+        return jsonResponse(topicDetail("t-1", "focused detail", { focus: "focused-message" }))
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        detailRequestCount += 1
+        if (detailRequestCount === 1) {
+          return jsonResponse(topicDetail("t-1", "hello from alpha"))
+        }
+        if (detailRequestCount === 2) {
+          return staleRefresh
+        }
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderAppWithControls(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 0,
+      message_count: 0,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "stale reviewer",
+          last_seq: 0,
+          updated_at: 1_700_000_250,
+        },
+      ],
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Focus same topic" }))
+
+    expect(await screen.findByText("focused detail")).toBeInTheDocument()
+
+    resolveStaleRefresh(
+      new Response(JSON.stringify(topicDetail("t-1", "stale detail")), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )
+
+    await waitFor(() => expect(screen.queryByText("stale detail")).not.toBeInTheDocument())
+    expect(screen.getByText("focused detail")).toBeInTheDocument()
   })
 })

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -17,10 +17,10 @@ const topicsPayload: { topics: TopicSummary[] } = {
       closed_at: null,
       close_reason: null,
       metadata: null,
-      message_count: 2,
-      last_seq: 2,
-      last_message_at: 1_700_000_120,
-      last_updated_at: 1_700_000_120,
+      message_count: 1,
+      last_seq: 1,
+      last_message_at: 1_700_000_100,
+      last_updated_at: 1_700_000_100,
     },
     {
       topic_id: "t-2",
@@ -427,6 +427,114 @@ describe("App", () => {
       fetchSpy.mock.calls.filter(([input]) =>
         String(input).includes("/api/topics/t-1/messages")
       )
+    ).toHaveLength(2)
+  })
+
+  test("falls back to full topic detail when append catch-up exceeds the page cap", async () => {
+    const appendBatches = new Map(
+      [1, 201, 401, 601, 801].map((afterSeq) => [
+        String(afterSeq),
+        Array.from({ length: 200 }, (_, index) => {
+          const seq = afterSeq + index + 1
+          return {
+            message_id: `t-1-m-${seq}`,
+            topic_id: "t-1",
+            seq,
+            sender: "reviewer",
+            message_type: "message",
+            reply_to: null,
+            reply_to_sender: null,
+            content_markdown: `message ${seq}`,
+            metadata: null,
+            client_message_id: null,
+            created_at: 1_700_001_000 + seq,
+          }
+        }),
+      ])
+    )
+
+    let currentDetail: TopicDetailResponse = topicDetail("t-1", "hello from alpha")
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(currentDetail)
+      }
+      if (url.pathname === "/api/topics/t-1/messages") {
+        const afterSeq = url.searchParams.get("after_seq")
+        const messages = afterSeq ? appendBatches.get(afterSeq) : null
+
+        if (messages) {
+          return jsonResponse({
+            messages,
+            first_seq: messages[0]?.seq ?? null,
+            last_seq: messages[messages.length - 1]?.seq ?? null,
+            has_earlier: false,
+          })
+        }
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    currentDetail = {
+      ...currentDetail,
+      messages: [
+        {
+          message_id: "t-1-m-1205",
+          topic_id: "t-1",
+          seq: 1205,
+          sender: "reviewer",
+          message_type: "message",
+          reply_to: null,
+          reply_to_sender: null,
+          content_markdown: "message 1205",
+          metadata: null,
+          client_message_id: null,
+          created_at: 1_700_002_205,
+        },
+      ],
+      message_count: 1205,
+      first_seq: 1205,
+      last_seq: 1205,
+      topic: {
+        ...currentDetail.topic,
+        message_count: 1205,
+        last_seq: 1205,
+        last_message_at: 1_700_002_205,
+        last_updated_at: 1_700_002_205,
+      },
+    }
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 1205,
+      message_count: 1205,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "bulk sender",
+          last_seq: 1205,
+          updated_at: 1_700_002_210,
+        },
+      ],
+    })
+
+    expect(await screen.findByText("message 1205")).toBeInTheDocument()
+    expect(
+      fetchSpy.mock.calls.filter(([input]) =>
+        String(input).includes("/api/topics/t-1/messages")
+      )
+    ).toHaveLength(5)
+    expect(
+      fetchSpy.mock.calls.filter(([input]) => String(input) === "/api/topics/t-1")
     ).toHaveLength(2)
   })
 })

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,9 +4,10 @@ import { describe, expect, test, vi } from "vitest"
 
 import App from "@/App"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import type { TopicDetailResponse, TopicSummary } from "@/lib/types"
 import { DEFAULT_WORKBENCH_STATE, loadWorkbenchState } from "@/lib/workbench-state"
 
-const topicsPayload = {
+const topicsPayload: { topics: TopicSummary[] } = {
   topics: [
     {
       topic_id: "t-1",
@@ -37,7 +38,11 @@ const topicsPayload = {
   ],
 }
 
-function topicDetail(topicId: string, content: string, options?: { focus?: string | null }) {
+function topicDetail(
+  topicId: string,
+  content: string,
+  options?: { focus?: string | null }
+): TopicDetailResponse {
   return {
     topic: topicsPayload.topics.find((topic) => topic.topic_id === topicId)!,
     messages: [
@@ -130,6 +135,18 @@ function renderApp(initialEntries: string[]) {
       </MemoryRouter>
     </TooltipProvider>
   )
+}
+
+function topicStream(topicId: string) {
+  const EventSourceCtor = globalThis.EventSource as unknown as {
+    instances: Array<{ url: string; emit: (type: string, payload?: unknown) => void }>
+  }
+
+  const stream = EventSourceCtor.instances.find(
+    (instance) => instance.url === `/api/stream/topics/${topicId}`
+  )
+  expect(stream).toBeDefined()
+  return stream!
 }
 
 describe("App", () => {
@@ -237,5 +254,179 @@ describe("App", () => {
       ...DEFAULT_WORKBENCH_STATE,
       openTopicIds: ["t-1"],
     })
+  })
+
+  test("refetches full topic detail when a stream update moves backward", async () => {
+    let currentDetail: TopicDetailResponse = topicDetail("t-1", "hello from alpha")
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(currentDetail)
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    currentDetail = {
+      ...currentDetail,
+      messages: [],
+      message_count: 0,
+      first_seq: null,
+      last_seq: null,
+      topic: {
+        ...currentDetail.topic,
+        message_count: 0,
+        last_seq: 0,
+      },
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "remote reviewer",
+          last_seq: 0,
+          updated_at: 1_700_000_220,
+        },
+      ],
+    }
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 0,
+      message_count: 0,
+      presence: currentDetail.presence,
+    })
+
+    await waitFor(() => expect(screen.queryByText("hello from alpha")).not.toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByText("remote reviewer").length).toBeGreaterThan(0))
+    expect(fetchSpy).toHaveBeenCalledWith("/api/topics/t-1", expect.any(Object))
+  })
+
+  test("keeps presence in sync even when append refresh fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(topicDetail("t-1", "hello from alpha"))
+      }
+      if (url.pathname === "/api/topics/t-1/messages") {
+        return Promise.reject(new Error("stream append fetch failed"))
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 2,
+      message_count: 2,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "append probe",
+          last_seq: 2,
+          updated_at: 1_700_000_330,
+        },
+      ],
+    })
+
+    await waitFor(() => expect(screen.getAllByText("append probe").length).toBeGreaterThan(0))
+    expect(screen.getByText("hello from alpha")).toBeInTheDocument()
+  })
+
+  test("drains multiple append pages for one stream update", async () => {
+    const batchOne = Array.from({ length: 200 }, (_, index) => ({
+      message_id: `t-1-m-${index + 2}`,
+      topic_id: "t-1",
+      seq: index + 2,
+      sender: "reviewer",
+      message_type: "message",
+      reply_to: null,
+      reply_to_sender: null,
+      content_markdown: `message ${index + 2}`,
+      metadata: null,
+      client_message_id: null,
+      created_at: 1_700_000_200 + index,
+    }))
+    const batchTwo = Array.from({ length: 4 }, (_, index) => ({
+      message_id: `t-1-m-${index + 202}`,
+      topic_id: "t-1",
+      seq: index + 202,
+      sender: "reviewer",
+      message_type: "message",
+      reply_to: null,
+      reply_to_sender: null,
+      content_markdown: `message ${index + 202}`,
+      metadata: null,
+      client_message_id: null,
+      created_at: 1_700_000_500 + index,
+    }))
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(topicDetail("t-1", "hello from alpha"))
+      }
+      if (url.pathname === "/api/topics/t-1/messages" && url.searchParams.get("after_seq") === "1") {
+        return jsonResponse({
+          messages: batchOne,
+          first_seq: 2,
+          last_seq: 201,
+          has_earlier: false,
+        })
+      }
+      if (url.pathname === "/api/topics/t-1/messages" && url.searchParams.get("after_seq") === "201") {
+        return jsonResponse({
+          messages: batchTwo,
+          first_seq: 202,
+          last_seq: 205,
+          has_earlier: false,
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 205,
+      message_count: 205,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "bulk sender",
+          last_seq: 205,
+          updated_at: 1_700_000_440,
+        },
+      ],
+    })
+
+    expect(await screen.findByText("message 205")).toBeInTheDocument()
+    expect(
+      fetchSpy.mock.calls.filter(([input]) =>
+        String(input).includes("/api/topics/t-1/messages")
+      )
+    ).toHaveLength(2)
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1166,12 +1166,6 @@ export default function App() {
         payload.last_seq === currentLastSeq &&
         payload.message_count === currentDetail.message_count
       ) {
-        setTopicDetail((current) => {
-          if (!current || current.topic.topic_id !== topicId) {
-            return current
-          }
-          return current
-        })
         return
       }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1062,52 +1062,77 @@ export default function App() {
       const payload = JSON.parse((event as MessageEvent<string>).data) as {
         topic_id: string
         last_seq: number
+        message_count: number
         presence: CursorPresence[]
       }
 
-      setTopicDetail((current) => {
-        if (!current || current.topic.topic_id !== topicId) {
-          return current
-        }
-        return {
-          ...current,
-          presence: payload.presence,
-        }
-      })
-
       const currentDetail = topicDetailRef.current
-      if (!currentDetail || currentDetail.topic.topic_id !== topicId || currentDetail.context_mode) {
-        return
-      }
-      if (payload.last_seq <= (currentDetail.last_seq ?? 0)) {
+      if (!currentDetail || currentDetail.topic.topic_id !== topicId) {
         return
       }
 
-      try {
-        const nextMessages = await fetchTopicMessages(topicId, {
-          afterSeq: currentDetail.last_seq ?? 0,
-          limit: 200,
-        })
+      const currentLastSeq = currentDetail.last_seq ?? 0
+      const appendOnly =
+        !currentDetail.context_mode &&
+        payload.last_seq > currentLastSeq &&
+        payload.message_count >= currentDetail.message_count
+
+      if (appendOnly) {
+        try {
+          const nextMessages = await fetchTopicMessages(topicId, {
+            afterSeq: currentLastSeq,
+            limit: 200,
+          })
+          setTopicDetail((current) => {
+            if (!current || current.topic.topic_id !== topicId) {
+              return current
+            }
+            const messages = mergeMessages(current.messages, nextMessages.messages)
+            const addedCount = messages.length - current.messages.length
+            return {
+              ...current,
+              messages,
+              first_seq: messages[0]?.seq ?? current.first_seq,
+              last_seq: messages[messages.length - 1]?.seq ?? current.last_seq,
+              message_count: current.message_count + Math.max(addedCount, 0),
+              topic: {
+                ...current.topic,
+                message_count: current.topic.message_count + Math.max(addedCount, 0),
+                last_seq: payload.last_seq,
+                last_updated_at: Date.now() / 1000,
+              },
+              presence: payload.presence,
+            }
+          })
+        } catch {
+          // Ignore transient stream refresh failures; the next event or manual refresh will catch up.
+        }
+        return
+      }
+
+      if (
+        payload.last_seq === currentLastSeq &&
+        payload.message_count === currentDetail.message_count
+      ) {
         setTopicDetail((current) => {
           if (!current || current.topic.topic_id !== topicId) {
             return current
           }
-          const messages = mergeMessages(current.messages, nextMessages.messages)
-          const addedCount = messages.length - current.messages.length
           return {
             ...current,
-            messages,
-            first_seq: messages[0]?.seq ?? current.first_seq,
-            last_seq: messages[messages.length - 1]?.seq ?? current.last_seq,
-            message_count: current.message_count + Math.max(addedCount, 0),
-            topic: {
-              ...current.topic,
-              message_count: current.topic.message_count + Math.max(addedCount, 0),
-              last_seq: payload.last_seq,
-              last_updated_at: Date.now() / 1000,
-            },
             presence: payload.presence,
           }
+        })
+        return
+      }
+
+      try {
+        const refreshedDetail = await fetchTopicDetail(topicId, currentDetail.focus_message_id)
+        setTopicDetail((current) => {
+          if (!current || current.topic.topic_id !== topicId) {
+            return current
+          }
+          return refreshedDetail
         })
       } catch {
         // Ignore transient stream refresh failures; the next event or manual refresh will catch up.
@@ -1458,7 +1483,7 @@ export default function App() {
                       <img
                         src="/app-mark.svg"
                         alt=""
-                        className="h-auto w-full max-w-[15rem] opacity-95"
+                        className="h-auto w-full max-w-[18.5rem] opacity-95"
                         aria-hidden="true"
                       />
                       <div className="flex max-w-lg flex-col gap-2">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -885,6 +885,10 @@ export default function App() {
   }, [topicDetail])
 
   useEffect(() => {
+    topicStreamUpdateTokenRef.current += 1
+  }, [focusMessageId, routeTopicId])
+
+  useEffect(() => {
     if (restoredInitialRoute.current) {
       return
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -865,6 +865,7 @@ export default function App() {
   const [selectionMode, setSelectionMode] = useState(false)
   const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(new Set())
   const topicDetailRef = useRef<TopicDetailResponse | null>(null)
+  const topicStreamUpdateTokenRef = useRef(0)
   const restoredInitialRoute = useRef(false)
   const sidebarSearchInputRef = useRef<HTMLInputElement | null>(null)
   const topicFindInputRef = useRef<HTMLInputElement | null>(null)
@@ -1067,6 +1068,8 @@ export default function App() {
         return
       }
 
+      const updateToken = ++topicStreamUpdateTokenRef.current
+
       setTopicDetail((current) => {
         if (!current || current.topic.topic_id !== topicId) {
           return current
@@ -1082,12 +1085,15 @@ export default function App() {
       const appendOnly =
         !currentDetail.context_mode &&
         payload.last_seq > currentLastSeq &&
-        payload.message_count >= currentDetail.message_count
+        payload.message_count > currentDetail.message_count
 
       async function refreshTopicDetail() {
         const refreshedDetail = await fetchTopicDetail(topicId, currentFocusMessageId)
         setTopicDetail((current) => {
           if (!current || current.topic.topic_id !== topicId) {
+            return current
+          }
+          if (updateToken !== topicStreamUpdateTokenRef.current) {
             return current
           }
           return {
@@ -1139,6 +1145,9 @@ export default function App() {
             if (!current || current.topic.topic_id !== topicId) {
               return current
             }
+            if (updateToken !== topicStreamUpdateTokenRef.current) {
+              return current
+            }
             const messages = mergeMessages(current.messages, appendedMessages)
             return {
               ...current,
@@ -1183,6 +1192,7 @@ export default function App() {
     stream.addEventListener("topic.update", handleUpdate)
     stream.addEventListener("topic.deleted", handleDeleted)
     return () => {
+      topicStreamUpdateTokenRef.current += 1
       stream.removeEventListener("topic.update", handleUpdate)
       stream.removeEventListener("topic.deleted", handleDeleted)
       stream.close()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1071,33 +1071,85 @@ export default function App() {
         return
       }
 
+      setTopicDetail((current) => {
+        if (!current || current.topic.topic_id !== topicId) {
+          return current
+        }
+        return {
+          ...current,
+          presence: payload.presence,
+        }
+      })
+
       const currentLastSeq = currentDetail.last_seq ?? 0
+      const currentFocusMessageId = currentDetail.focus_message_id
       const appendOnly =
         !currentDetail.context_mode &&
         payload.last_seq > currentLastSeq &&
         payload.message_count >= currentDetail.message_count
 
+      async function refreshTopicDetail() {
+        const refreshedDetail = await fetchTopicDetail(topicId, currentFocusMessageId)
+        setTopicDetail((current) => {
+          if (!current || current.topic.topic_id !== topicId) {
+            return current
+          }
+          return {
+            ...refreshedDetail,
+            presence: payload.presence,
+          }
+        })
+      }
+
       if (appendOnly) {
         try {
-          const nextMessages = await fetchTopicMessages(topicId, {
-            afterSeq: currentLastSeq,
-            limit: 200,
-          })
+          const pageLimit = 200
+          let afterSeq = currentLastSeq
+          let appendedMessages: TopicMessage[] = []
+
+          while (afterSeq < payload.last_seq) {
+            const nextMessages = await fetchTopicMessages(topicId, {
+              afterSeq,
+              limit: pageLimit,
+            })
+            const batch = nextMessages.messages
+
+            if (batch.length === 0) {
+              break
+            }
+
+            appendedMessages = mergeMessages(appendedMessages, batch)
+
+            const batchLastSeq = batch[batch.length - 1]?.seq ?? afterSeq
+            if (batchLastSeq <= afterSeq) {
+              break
+            }
+            afterSeq = batchLastSeq
+
+            if (batch.length < pageLimit) {
+              break
+            }
+          }
+
+          if (afterSeq < payload.last_seq) {
+            await refreshTopicDetail()
+            return
+          }
+
           setTopicDetail((current) => {
             if (!current || current.topic.topic_id !== topicId) {
               return current
             }
-            const messages = mergeMessages(current.messages, nextMessages.messages)
-            const addedCount = messages.length - current.messages.length
+            const messages = mergeMessages(current.messages, appendedMessages)
             return {
               ...current,
               messages,
               first_seq: messages[0]?.seq ?? current.first_seq,
               last_seq: messages[messages.length - 1]?.seq ?? current.last_seq,
-              message_count: current.message_count + Math.max(addedCount, 0),
+              message_count: payload.message_count,
               topic: {
                 ...current.topic,
-                message_count: current.topic.message_count + Math.max(addedCount, 0),
+                message_count: payload.message_count,
                 last_seq: payload.last_seq,
                 last_updated_at: Date.now() / 1000,
               },
@@ -1118,22 +1170,13 @@ export default function App() {
           if (!current || current.topic.topic_id !== topicId) {
             return current
           }
-          return {
-            ...current,
-            presence: payload.presence,
-          }
+          return current
         })
         return
       }
 
       try {
-        const refreshedDetail = await fetchTopicDetail(topicId, currentDetail.focus_message_id)
-        setTopicDetail((current) => {
-          if (!current || current.topic.topic_id !== topicId) {
-            return current
-          }
-          return refreshedDetail
-        })
+        await refreshTopicDetail()
       } catch {
         // Ignore transient stream refresh failures; the next event or manual refresh will catch up.
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import type {
   TopicMessage,
   TopicSort,
   TopicStatusFilter,
+  TopicStreamUpdate,
   TopicSummary,
   WorkbenchState,
 } from "@/lib/types"
@@ -1059,12 +1060,7 @@ export default function App() {
     const stream = new EventSource(`/api/stream/topics/${topicId}`)
 
     async function handleUpdate(event: Event) {
-      const payload = JSON.parse((event as MessageEvent<string>).data) as {
-        topic_id: string
-        last_seq: number
-        message_count: number
-        presence: CursorPresence[]
-      }
+      const payload = JSON.parse((event as MessageEvent<string>).data) as TopicStreamUpdate
 
       const currentDetail = topicDetailRef.current
       if (!currentDetail || currentDetail.topic.topic_id !== topicId) {
@@ -1104,15 +1100,18 @@ export default function App() {
       if (appendOnly) {
         try {
           const pageLimit = 200
+          const maxAppendPages = 5
           let afterSeq = currentLastSeq
           let appendedMessages: TopicMessage[] = []
+          let pagesFetched = 0
 
-          while (afterSeq < payload.last_seq) {
+          while (afterSeq < payload.last_seq && pagesFetched < maxAppendPages) {
             const nextMessages = await fetchTopicMessages(topicId, {
               afterSeq,
               limit: pageLimit,
             })
             const batch = nextMessages.messages
+            pagesFetched += 1
 
             if (batch.length === 0) {
               break

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -84,6 +84,7 @@ export interface SearchResponse {
 export interface TopicStreamUpdate {
   topic_id: string
   last_seq: number
+  message_count: number
   presence: CursorPresence[]
 }
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -5,12 +5,14 @@ import { cleanup } from "@testing-library/react"
 type EventListenerMap = Map<string, Set<EventListenerOrEventListenerObject>>
 
 class MockEventSource {
+  static instances: MockEventSource[] = []
   listeners: EventListenerMap = new Map()
   onmessage: ((event: MessageEvent<string>) => void) | null = null
   url: string
 
   constructor(url: string) {
     this.url = url
+    MockEventSource.instances.push(this)
   }
 
   addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
@@ -25,6 +27,24 @@ class MockEventSource {
   }
 
   close() {}
+
+  emit(type: string, payload?: unknown) {
+    const event = payload === undefined
+      ? ({} as Event)
+      : ({ data: JSON.stringify(payload) } as MessageEvent<string>)
+
+    for (const listener of this.listeners.get(type) ?? []) {
+      if (typeof listener === "function") {
+        listener(event)
+      } else {
+        listener.handleEvent(event)
+      }
+    }
+
+    if (type === "message" && payload !== undefined) {
+      this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent<string>)
+    }
+  }
 }
 
 Object.defineProperty(globalThis, "EventSource", {
@@ -54,6 +74,7 @@ Object.defineProperty(window, "localStorage", {
 
 beforeEach(() => {
   window.localStorage.clear()
+  MockEventSource.instances = []
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Closes #35.

- treat topic-stream updates as append-only only when both `last_seq` and `message_count` move forward
- refetch full topic detail when the stream reports a backward/non-append change, so deletions resync the open page without a manual refresh
- add `message_count` to the typed topic stream payload
- refresh the workbench empty-state mark with the newly selected SVG and keep it slightly larger in the empty state

## Validation

- `pnpm --dir frontend test`
- `pnpm --dir frontend build`
- `uv run ty check`
- manual live verification in Chrome against `http://127.0.0.1:8080/topics/6838f03136`
  - append updated sidebar/header/inspector/message row live
  - delete updated the same open page back to 12 messages without reload
