### PR TITLE
fix(search): clarify hybrid snippets and highlights

### DIFF
--- a/agent_bus/search.py
+++ b/agent_bus/search.py
@@ -15,6 +15,7 @@ DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
 DEFAULT_CHUNK_SIZE = 1200  # characters
 DEFAULT_CHUNK_OVERLAP = 200  # characters
 QUERY_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+FTS_QUERY_OPERATORS = {"and", "or", "not", "near"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -150,15 +151,19 @@ def _semantic_snippet(
 
 
 def _query_terms(query: str) -> list[str]:
-    return [term.lower() for term in QUERY_TOKEN_RE.findall(query) if len(term) >= 2]
+    return [
+        term.lower()
+        for term in QUERY_TOKEN_RE.findall(query)
+        if len(term) >= 2 and term.lower() not in FTS_QUERY_OPERATORS
+    ]
 
 
 def _snippet_contains_query_terms(snippet: str, *, query: str) -> bool:
-    query_terms = _query_terms(query)
-    if not query_terms:
+    query_term_set = set(_query_terms(query))
+    if not query_term_set:
         return False
-    haystack = snippet.lower()
-    return any(term in haystack for term in query_terms)
+    snippet_term_set = {term.lower() for term in QUERY_TOKEN_RE.findall(snippet) if len(term) >= 2}
+    return bool(query_term_set & snippet_term_set)
 
 
 def search_messages(

--- a/agent_bus/search.py
+++ b/agent_bus/search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Literal, cast
@@ -13,6 +14,7 @@ SearchMode = Literal["fts", "semantic", "hybrid"]
 DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
 DEFAULT_CHUNK_SIZE = 1200  # characters
 DEFAULT_CHUNK_OVERLAP = 200  # characters
+QUERY_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,6 +149,18 @@ def _semantic_snippet(
     return snippet
 
 
+def _query_terms(query: str) -> list[str]:
+    return [term.lower() for term in QUERY_TOKEN_RE.findall(query) if len(term) >= 2]
+
+
+def _snippet_contains_query_terms(snippet: str, *, query: str) -> bool:
+    query_terms = _query_terms(query)
+    if not query_terms:
+        return False
+    haystack = snippet.lower()
+    return any(term in haystack for term in query_terms)
+
+
 def search_messages(
     db: AgentBusDB,
     *,
@@ -257,12 +271,17 @@ def search_messages(
         best_row = best.get(mid)
         if best_row is not None:
             semantic_score = float(best_row["semantic_score"])
-            snippet = _semantic_snippet(
+            semantic_snippet = _semantic_snippet(
                 db,
                 message_id=mid,
                 start_char=int(best_row["start_char"]),
                 end_char=int(best_row["end_char"]),
                 content_cache=content_cache,
+            )
+            snippet = (
+                semantic_snippet
+                if _snippet_contains_query_terms(semantic_snippet, query=query)
+                else r["snippet"]
             )
         else:
             semantic_score = None

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -326,6 +326,57 @@ describe("App", () => {
     })
   })
 
+  test("highlights Unicode case-insensitive matches without misaligned ranges", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-2" && url.searchParams.get("focus") === "focused-message") {
+        return jsonResponse(
+          topicDetail("t-2", "İstanbul handoff context", { focus: "focused-message" })
+        )
+      }
+      if (url.pathname === "/api/search") {
+        return jsonResponse({
+          query: url.searchParams.get("q") ?? "",
+          mode: "hybrid",
+          warnings: [],
+          results: [
+            {
+              topic_id: "t-2",
+              topic_name: "Beta thread",
+              message_id: "focused-message",
+              seq: 7,
+              sender: "architect",
+              message_type: "message",
+              snippet: "İstanbul handoff",
+              semantic_score: 0.81,
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    const { container } = renderApp(["/"])
+
+    fireEvent.change(await screen.findByPlaceholderText(/^Search$/i), {
+      target: { value: "istanbul" },
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: /Beta thread/i }))
+
+    await waitFor(() => {
+      const highlightedText = Array.from(container.querySelectorAll("mark[data-ab-highlight='true']")).map(
+        (element) => element.textContent ?? ""
+      )
+      expect(highlightedText).toContain("İstanbul")
+    })
+  })
+
   test("labels fts-only sidebar results using fts_rank", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       const url = new URL(String(input), "http://localhost")
@@ -398,6 +449,45 @@ describe("App", () => {
         )
       ).toBe(true)
     )
+  })
+
+  test("focused-message navigation does not suppress the first later local-find scroll", async () => {
+    const scrollIntoViewSpy = vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => {})
+    let detailRequestCount = 0
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1" && url.searchParams.get("focus") === "focused-message") {
+        return jsonResponse(topicDetail("t-1", "focused detail", { focus: "focused-message" }))
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        detailRequestCount += 1
+        if (detailRequestCount === 1) {
+          return jsonResponse(topicDetail("t-1", "hello from alpha"))
+        }
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderAppWithControls(["/topics/t-1"])
+
+    expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Focus same topic" }))
+    expect(await screen.findByText("focused detail")).toBeInTheDocument()
+
+    scrollIntoViewSpy.mockClear()
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true })
+    fireEvent.change(await screen.findByPlaceholderText(/Find in this thread/i), {
+      target: { value: "focused" },
+    })
+
+    expect(await screen.findByText("1/1")).toBeInTheDocument()
+    await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled())
   })
 
   test("focuses the sidebar search with the keyboard shortcut", async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -7,8 +7,8 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import type { TopicDetailResponse, TopicSummary } from "@/lib/types"
 import { DEFAULT_WORKBENCH_STATE, loadWorkbenchState } from "@/lib/workbench-state"
 
-const SEARCH_HIGHLIGHT_START = "__AB_HL_START__"
-const SEARCH_HIGHLIGHT_END = "__AB_HL_END__"
+const SEARCH_HIGHLIGHT_START = "\uE000"
+const SEARCH_HIGHLIGHT_END = "\uE001"
 
 const topicsPayload: { topics: TopicSummary[] } = {
   topics: [
@@ -324,6 +324,45 @@ describe("App", () => {
       )
       expect(highlightedText).toContain("handoff")
     })
+  })
+
+  test("labels fts-only sidebar results using fts_rank", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/search") {
+        return jsonResponse({
+          query: url.searchParams.get("q") ?? "",
+          mode: "hybrid",
+          warnings: [],
+          results: [
+            {
+              topic_id: "t-2",
+              topic_name: "Beta thread",
+              message_id: "focused-message",
+              seq: 7,
+              sender: "architect",
+              message_type: "message",
+              snippet: `beta ${SEARCH_HIGHLIGHT_START}handoff${SEARCH_HIGHLIGHT_END} summary`,
+              fts_rank: 0.2,
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/"])
+
+    fireEvent.change(await screen.findByPlaceholderText(/^Search$/i), {
+      target: { value: "handoff" },
+    })
+
+    expect(await screen.findByText(/^fts$/i)).toBeInTheDocument()
   })
 
   test("renders search snippets as text instead of attacker-controlled HTML", async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -7,6 +7,9 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import type { TopicDetailResponse, TopicSummary } from "@/lib/types"
 import { DEFAULT_WORKBENCH_STATE, loadWorkbenchState } from "@/lib/workbench-state"
 
+const SEARCH_HIGHLIGHT_START = "__AB_HL_START__"
+const SEARCH_HIGHLIGHT_END = "__AB_HL_END__"
+
 const topicsPayload: { topics: TopicSummary[] } = {
   topics: [
     {
@@ -117,7 +120,7 @@ function installFetchMock() {
             seq: 7,
             sender: "architect",
             message_type: "message",
-            snippet: '<img src=x onerror=alert(1)> [handoff] summary',
+            snippet: `<img src=x onerror=alert(1)> ${SEARCH_HIGHLIGHT_START}handoff${SEARCH_HIGHLIGHT_END} summary`,
             semantic_score: 0.81,
           },
         ],
@@ -202,7 +205,7 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Close Alpha review/i }))
 
-    expect(await screen.findByText(/Agent Bus Workbench/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Agent Bus MCP Workbench/i)).toBeInTheDocument()
   })
 
   test("uses the sidebar search to navigate to a focused result", async () => {
@@ -218,6 +221,109 @@ describe("App", () => {
     fireEvent.click(result)
 
     await waitFor(() => expect(screen.getByText("beta context")).toBeInTheDocument())
+  })
+
+  test("highlights lexical sidebar matches inside the focused message", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-2" && url.searchParams.get("focus") === "focused-message") {
+        return jsonResponse(
+          topicDetail("t-2", "beta handoff summary context", { focus: "focused-message" })
+        )
+      }
+      if (url.pathname === "/api/search") {
+        return jsonResponse({
+          query: url.searchParams.get("q") ?? "",
+          mode: "hybrid",
+          warnings: [],
+          results: [
+            {
+              topic_id: "t-2",
+              topic_name: "Beta thread",
+              message_id: "focused-message",
+              seq: 7,
+              sender: "architect",
+              message_type: "message",
+              snippet: `beta ${SEARCH_HIGHLIGHT_START}handoff${SEARCH_HIGHLIGHT_END} summary`,
+              rank: 0.2,
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    const { container } = renderApp(["/"])
+
+    fireEvent.change(await screen.findByPlaceholderText(/^Search$/i), {
+      target: { value: "handoff" },
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: /Beta thread/i }))
+
+    await waitFor(() =>
+      expect(
+        Array.from(container.querySelectorAll("mark[data-ab-highlight='true']")).some(
+          (element) => element.textContent === "handoff"
+        )
+      ).toBe(true)
+    )
+  })
+
+  test("highlights overlapping query terms for semantic results", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-2" && url.searchParams.get("focus") === "focused-message") {
+        return jsonResponse(
+          topicDetail("t-2", "beta handoff\nsummary context", { focus: "focused-message" })
+        )
+      }
+      if (url.pathname === "/api/search") {
+        return jsonResponse({
+          query: url.searchParams.get("q") ?? "",
+          mode: "hybrid",
+          warnings: [],
+          results: [
+            {
+              topic_id: "t-2",
+              topic_name: "Beta thread",
+              message_id: "focused-message",
+              seq: 7,
+              sender: "architect",
+              message_type: "message",
+              snippet: "handoff summary",
+              semantic_score: 0.81,
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    const { container } = renderApp(["/"])
+
+    fireEvent.change(await screen.findByPlaceholderText(/^Search$/i), {
+      target: { value: "semantic handoff" },
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: /Beta thread/i }))
+
+    await waitFor(() => {
+      const highlightedText = Array.from(container.querySelectorAll("mark[data-ab-highlight='true']")).map(
+        (element) => element.textContent ?? ""
+      )
+      expect(highlightedText).toContain("handoff")
+    })
   })
 
   test("renders search snippets as text instead of attacker-controlled HTML", async () => {
@@ -237,7 +343,7 @@ describe("App", () => {
   test("opens local find with the keyboard shortcut inside the active topic", async () => {
     installFetchMock()
 
-    renderApp(["/topics/t-1"])
+    const { container } = renderApp(["/topics/t-1"])
 
     expect(await screen.findByText("hello from alpha")).toBeInTheDocument()
     fireEvent.keyDown(window, { key: "f", metaKey: true })
@@ -246,6 +352,13 @@ describe("App", () => {
     })
 
     expect(await screen.findByText("1/1")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        Array.from(container.querySelectorAll("mark[data-ab-highlight='true']")).some(
+          (element) => element.textContent === "alpha"
+        )
+      ).toBe(true)
+    )
   })
 
   test("focuses the sidebar search with the keyboard shortcut", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,8 +90,8 @@ type MessageHighlightSpec = {
   terms: string[]
 }
 
-const SEARCH_HIGHLIGHT_START = "__AB_HL_START__"
-const SEARCH_HIGHLIGHT_END = "__AB_HL_END__"
+const SEARCH_HIGHLIGHT_START = "\uE000"
+const SEARCH_HIGHLIGHT_END = "\uE001"
 
 const SIDEBAR_LAYOUT_STYLE = {
   "--sidebar-width": "22rem",
@@ -142,7 +142,10 @@ function snippetLabel(result: SearchResult): string {
   if (result.semantic_score !== undefined && result.semantic_score !== null) {
     return `semantic ${result.semantic_score.toFixed(4)}`
   }
-  if (result.rank !== undefined && result.rank !== null) {
+  if (
+    (result.rank !== undefined && result.rank !== null) ||
+    (result.fts_rank !== undefined && result.fts_rank !== null)
+  ) {
     return "fts"
   }
   return result.message_type
@@ -460,7 +463,7 @@ function MessageMarkdown(props: { content: string; highlight: MessageHighlightSp
     return () => {
       clearMessageHighlights(container)
     }
-  }, [content, highlightTermsKey, highlight])
+  }, [content, highlightTermsKey])
 
   return (
     <div ref={containerRef} className="min-w-0 text-sm">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -186,6 +186,10 @@ function uniqueStrings(values: string[]): string[] {
   return out
 }
 
+function normalizeSearchText(value: string): string {
+  return value.toLocaleLowerCase().normalize("NFKD").replace(/\p{M}+/gu, "")
+}
+
 function splitSearchSnippet(snippet: string): Array<{ text: string; highlight: boolean }> {
   const parts: Array<{ text: string; highlight: boolean }> = []
   let cursor = 0
@@ -263,22 +267,38 @@ function findTermRanges(text: string, terms: string[]): TextRange[] {
     return []
   }
 
-  const haystack = text.toLocaleLowerCase()
+  const haystack = normalizeSearchText(text)
+  const normalizedIndexToOriginalRange: TextRange[] = []
+  let originalIndex = 0
+  for (const char of text) {
+    const start = originalIndex
+    const end = start + char.length
+    for (const _normalizedChar of normalizeSearchText(char)) {
+      normalizedIndexToOriginalRange.push({ start, end })
+    }
+    originalIndex = end
+  }
+
   const ranges: TextRange[] = []
 
   for (const term of uniqueStrings(terms)) {
-    const needle = term.toLocaleLowerCase()
+    const needle = normalizeSearchText(term)
     if (!needle) {
       continue
     }
-    let startIndex = 0
-    while (startIndex < haystack.length) {
-      const matchIndex = haystack.indexOf(needle, startIndex)
-      if (matchIndex === -1) {
+    let searchStart = 0
+    while (searchStart < haystack.length) {
+      const normalizedMatchIndex = haystack.indexOf(needle, searchStart)
+      if (normalizedMatchIndex === -1) {
         break
       }
-      ranges.push({ start: matchIndex, end: matchIndex + needle.length })
-      startIndex = matchIndex + Math.max(needle.length, 1)
+      const normalizedMatchEnd = normalizedMatchIndex + needle.length - 1
+      const start = normalizedIndexToOriginalRange[normalizedMatchIndex]?.start
+      const end = normalizedIndexToOriginalRange[normalizedMatchEnd]?.end
+      if (start !== undefined && end !== undefined && end > start) {
+        ranges.push({ start, end })
+      }
+      searchStart = normalizedMatchIndex + Math.max(needle.length, 1)
     }
   }
 
@@ -1474,26 +1494,6 @@ export default function App() {
     }
   }, [routeTopicId])
 
-  useEffect(() => {
-    if (!topicDetail?.focus_message_id) {
-      return
-    }
-    suppressNextFindScrollRef.current = true
-    const element = document.getElementById(`msg-${topicDetail.focus_message_id}`)
-    if (!element) {
-      return
-    }
-    element.scrollIntoView({ behavior: "smooth", block: "center" })
-  }, [topicDetail])
-
-  useEffect(() => {
-    activeTabRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "nearest",
-    })
-  }, [routeTopicId, workbenchState.openTopicIds])
-
   const topicFindMatches =
     topicDetail && topicFindState.query.trim()
       ? topicDetail.messages.filter((message) => messageContainsText(message, topicFindState.query.trim()))
@@ -1504,6 +1504,32 @@ export default function App() {
           (result) => result.topic_id === routeTopicId && result.message_id === focusMessageId
         ) ?? null
       : null
+
+  useEffect(() => {
+    if (!topicDetail?.focus_message_id) {
+      return
+    }
+    suppressNextFindScrollRef.current = topicFindState.open && topicFindMatches.length > 0
+    const element = document.getElementById(`msg-${topicDetail.focus_message_id}`)
+    if (!element) {
+      return
+    }
+    element.scrollIntoView({ behavior: "smooth", block: "center" })
+  }, [topicDetail, topicFindMatches.length, topicFindState.open])
+
+  useEffect(() => {
+    if (!topicFindState.open || !topicFindState.query.trim() || topicFindMatches.length === 0) {
+      suppressNextFindScrollRef.current = false
+    }
+  }, [topicFindMatches.length, topicFindState.open, topicFindState.query])
+
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    })
+  }, [routeTopicId, workbenchState.openTopicIds])
 
   useEffect(() => {
     setTopicFindState((current) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,6 +81,18 @@ type FindState = {
   activeIndex: number
 }
 
+type TextRange = {
+  start: number
+  end: number
+}
+
+type MessageHighlightSpec = {
+  terms: string[]
+}
+
+const SEARCH_HIGHLIGHT_START = "__AB_HL_START__"
+const SEARCH_HIGHLIGHT_END = "__AB_HL_END__"
+
 const SIDEBAR_LAYOUT_STYLE = {
   "--sidebar-width": "22rem",
   "--sidebar-width-mobile": "22rem",
@@ -119,32 +131,243 @@ function statusVariant(status: TopicSummary["status"]): "default" | "secondary" 
 }
 
 function snippetLabel(result: SearchResult): string {
+  if (
+    result.semantic_score !== undefined &&
+    result.semantic_score !== null &&
+    result.fts_rank !== undefined &&
+    result.fts_rank !== null
+  ) {
+    return `hybrid ${result.semantic_score.toFixed(4)}`
+  }
   if (result.semantic_score !== undefined && result.semantic_score !== null) {
-    return `semantic ${result.semantic_score.toFixed(3)}`
+    return `semantic ${result.semantic_score.toFixed(4)}`
   }
   if (result.rank !== undefined && result.rank !== null) {
-    return `rank ${result.rank.toFixed(3)}`
+    return "fts"
   }
   return result.message_type
 }
 
 function renderSnippet(snippet: string) {
-  const parts = snippet.split(/(\[[^\]]+\])/g).filter(Boolean)
+  const parts = splitSearchSnippet(snippet)
   return parts.map((part, index) => {
-    const isHighlight = part.startsWith("[") && part.endsWith("]")
-    const content = isHighlight ? part.slice(1, -1) : part
-    if (isHighlight) {
+    if (part.highlight) {
       return (
         <mark
           key={`snippet-${index}`}
           className="rounded-sm bg-primary/15 px-0.5 text-zinc-200"
         >
-          {content}
+          {part.text}
         </mark>
       )
     }
-    return <span key={`snippet-${index}`}>{content}</span>
+    return <span key={`snippet-${index}`}>{part.text}</span>
   })
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      continue
+    }
+    const key = trimmed.toLocaleLowerCase()
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}
+
+function splitSearchSnippet(snippet: string): Array<{ text: string; highlight: boolean }> {
+  const parts: Array<{ text: string; highlight: boolean }> = []
+  let cursor = 0
+
+  while (cursor < snippet.length) {
+    const start = snippet.indexOf(SEARCH_HIGHLIGHT_START, cursor)
+    if (start === -1) {
+      const text = snippet.slice(cursor)
+      if (text) {
+        parts.push({ text, highlight: false })
+      }
+      break
+    }
+
+    if (start > cursor) {
+      parts.push({ text: snippet.slice(cursor, start), highlight: false })
+    }
+
+    const highlightStart = start + SEARCH_HIGHLIGHT_START.length
+    const end = snippet.indexOf(SEARCH_HIGHLIGHT_END, highlightStart)
+    if (end === -1) {
+      parts.push({ text: snippet.slice(start), highlight: false })
+      break
+    }
+
+    const text = snippet.slice(highlightStart, end)
+    if (text) {
+      parts.push({ text, highlight: true })
+    }
+    cursor = end + SEARCH_HIGHLIGHT_END.length
+  }
+
+  return parts
+}
+
+function extractSnippetTerms(snippet: string): string[] {
+  return uniqueStrings(
+    splitSearchSnippet(snippet)
+      .filter((part) => part.highlight)
+      .map((part) => part.text)
+  )
+}
+
+function tokenizeSearchQuery(query: string): string[] {
+  return uniqueStrings(
+    query
+      .split(/\s+/u)
+      .map((part) => part.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ""))
+      .filter((part) => part.length >= 2)
+  )
+}
+
+function mergeRanges(ranges: TextRange[]): TextRange[] {
+  if (ranges.length === 0) {
+    return []
+  }
+  const merged: TextRange[] = []
+  const sorted = [...ranges].sort((left, right) => left.start - right.start || left.end - right.end)
+  for (const range of sorted) {
+    if (range.end <= range.start) {
+      continue
+    }
+    const last = merged.at(-1)
+    if (!last || range.start > last.end) {
+      merged.push({ ...range })
+      continue
+    }
+    last.end = Math.max(last.end, range.end)
+  }
+  return merged
+}
+
+function findTermRanges(text: string, terms: string[]): TextRange[] {
+  if (!text || terms.length === 0) {
+    return []
+  }
+
+  const haystack = text.toLocaleLowerCase()
+  const ranges: TextRange[] = []
+
+  for (const term of uniqueStrings(terms)) {
+    const needle = term.toLocaleLowerCase()
+    if (!needle) {
+      continue
+    }
+    let startIndex = 0
+    while (startIndex < haystack.length) {
+      const matchIndex = haystack.indexOf(needle, startIndex)
+      if (matchIndex === -1) {
+        break
+      }
+      ranges.push({ start: matchIndex, end: matchIndex + needle.length })
+      startIndex = matchIndex + Math.max(needle.length, 1)
+    }
+  }
+
+  return mergeRanges(ranges)
+}
+
+function clearMessageHighlights(root: HTMLElement): void {
+  root.querySelectorAll("mark[data-ab-highlight='true']").forEach((mark) => {
+    const parent = mark.parentNode
+    if (!parent) {
+      return
+    }
+    while (mark.firstChild) {
+      parent.insertBefore(mark.firstChild, mark)
+    }
+    parent.removeChild(mark)
+    parent.normalize()
+  })
+}
+
+function applyMessageHighlights(root: HTMLElement, spec: MessageHighlightSpec | null): void {
+  clearMessageHighlights(root)
+
+  if (!spec) {
+    return
+  }
+
+  const nodeFilter = root.ownerDocument.defaultView?.NodeFilter ?? NodeFilter
+  const walker = root.ownerDocument.createTreeWalker(root, nodeFilter.SHOW_TEXT)
+  const textNodes: Array<{ node: Text; start: number; end: number }> = []
+
+  let currentNode = walker.nextNode()
+  let cursor = 0
+  while (currentNode) {
+    const textNode = currentNode as Text
+    const value = textNode.data
+    if (value) {
+      textNodes.push({
+        node: textNode,
+        start: cursor,
+        end: cursor + value.length,
+      })
+      cursor += value.length
+    }
+    currentNode = walker.nextNode()
+  }
+
+  if (textNodes.length === 0) {
+    return
+  }
+
+  const fullText = textNodes.map((entry) => entry.node.data).join("")
+  const ranges = findTermRanges(fullText, spec.terms)
+
+  if (ranges.length === 0) {
+    return
+  }
+
+  for (const entry of [...textNodes].reverse()) {
+    const localRanges = ranges
+      .filter((range) => range.start < entry.end && range.end > entry.start)
+      .map((range) => ({
+        start: Math.max(range.start, entry.start) - entry.start,
+        end: Math.min(range.end, entry.end) - entry.start,
+      }))
+
+    if (localRanges.length === 0) {
+      continue
+    }
+
+    const fragment = root.ownerDocument.createDocumentFragment()
+    let localCursor = 0
+
+    for (const range of localRanges) {
+      if (range.start > localCursor) {
+        fragment.append(root.ownerDocument.createTextNode(entry.node.data.slice(localCursor, range.start)))
+      }
+      const mark = root.ownerDocument.createElement("mark")
+      mark.dataset.abHighlight = "true"
+      mark.className =
+        "rounded-sm bg-amber-300/45 px-0.5 text-amber-50 ring-1 ring-inset ring-amber-200/45"
+      mark.textContent = entry.node.data.slice(range.start, range.end)
+      fragment.append(mark)
+      localCursor = range.end
+    }
+
+    if (localCursor < entry.node.data.length) {
+      fragment.append(root.ownerDocument.createTextNode(entry.node.data.slice(localCursor)))
+    }
+
+    entry.node.parentNode?.replaceChild(fragment, entry.node)
+  }
 }
 
 function fallbackTopic(topicId: string): TopicSummary {
@@ -223,9 +446,24 @@ const markdownComponents: Components = {
   ),
 }
 
-function MessageMarkdown({ content }: { content: string }) {
+function MessageMarkdown(props: { content: string; highlight: MessageHighlightSpec | null }) {
+  const { content, highlight } = props
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const highlightTermsKey = highlight?.terms.join("\u0000") ?? ""
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    applyMessageHighlights(container, highlight)
+    return () => {
+      clearMessageHighlights(container)
+    }
+  }, [content, highlightTermsKey, highlight])
+
   return (
-    <div className="min-w-0 text-sm">
+    <div ref={containerRef} className="min-w-0 text-sm">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
         {content}
       </ReactMarkdown>
@@ -235,6 +473,7 @@ function MessageMarkdown({ content }: { content: string }) {
 
 function MessageCard(props: {
   message: TopicMessage
+  highlight: MessageHighlightSpec | null
   focused: boolean
   localMatched: boolean
   localActive: boolean
@@ -242,7 +481,7 @@ function MessageCard(props: {
   selected: boolean
   onSelectedChange: (next: boolean) => void
 }) {
-  const { message, focused, localMatched, localActive, selectable, selected, onSelectedChange } = props
+  const { message, highlight, focused, localMatched, localActive, selectable, selected, onSelectedChange } = props
 
   return (
     <article
@@ -283,7 +522,7 @@ function MessageCard(props: {
               <Badge variant="secondary">reply to {message.reply_to_sender}</Badge>
             ) : null}
           </div>
-          <MessageMarkdown content={message.content_markdown} />
+          <MessageMarkdown content={message.content_markdown} highlight={highlight} />
           <div className="text-xs text-muted-foreground">{formatAbsoluteTime(message.created_at)}</div>
         </div>
       </div>
@@ -293,6 +532,8 @@ function MessageCard(props: {
 
 function TopicView(props: {
   topicDetail: TopicDetailResponse
+  activeSearchResult: SearchResult | null
+  sidebarSearchQuery: string
   findState: FindState
   findMatches: TopicMessage[]
   selectionMode: boolean
@@ -310,6 +551,8 @@ function TopicView(props: {
 }) {
   const {
     topicDetail,
+    activeSearchResult,
+    sidebarSearchQuery,
     findState,
     findMatches,
     selectionMode,
@@ -330,6 +573,7 @@ function TopicView(props: {
     findState.query.trim() && findMatches.length > 0
       ? findMatches[Math.min(findState.activeIndex, findMatches.length - 1)]?.message_id ?? null
       : null
+  const activeSearchTerms = activeSearchResult ? extractSnippetTerms(activeSearchResult.snippet) : []
 
   return (
     <div className="grid h-full min-h-0 flex-1 grid-cols-1 gap-0 border border-border bg-card xl:grid-cols-[minmax(0,1fr)_12rem]">
@@ -452,21 +696,44 @@ function TopicView(props: {
                     </div>
                   </div>
                 ) : (
-                  topicDetail.messages.map((message) => (
-                    <MessageCard
-                      key={message.message_id}
-                      message={message}
-                      focused={topicDetail.focus_message_id === message.message_id}
-                      localMatched={
-                        Boolean(findState.query.trim()) &&
-                        findMatches.some((candidate) => candidate.message_id === message.message_id)
-                      }
-                      localActive={activeFindMessageId === message.message_id}
-                      selectable={selectionMode}
-                      selected={selectedMessageIds.has(message.message_id)}
-                      onSelectedChange={(next) => onMessageSelectionChange(message.message_id, next)}
-                    />
-                  ))
+                  topicDetail.messages.map((message) => {
+                    const localMatched =
+                      Boolean(findState.query.trim()) &&
+                      findMatches.some((candidate) => candidate.message_id === message.message_id)
+                    const localFindQuery = localMatched ? findState.query.trim() : null
+                    const focusedSearchMessage =
+                      activeSearchResult?.message_id === message.message_id ? activeSearchResult : null
+                    const highlightTerms = uniqueStrings([
+                      ...(localFindQuery ? [localFindQuery] : []),
+                      ...(focusedSearchMessage
+                        ? activeSearchTerms.length > 0
+                          ? activeSearchTerms
+                          : sidebarSearchQuery.trim()
+                            ? tokenizeSearchQuery(sidebarSearchQuery)
+                            : []
+                        : []),
+                    ])
+                    const highlight =
+                      highlightTerms.length > 0
+                        ? {
+                            terms: highlightTerms,
+                          }
+                        : null
+
+                    return (
+                      <MessageCard
+                        key={message.message_id}
+                        message={message}
+                        highlight={highlight}
+                        focused={topicDetail.focus_message_id === message.message_id}
+                        localMatched={localMatched}
+                        localActive={activeFindMessageId === message.message_id}
+                        selectable={selectionMode}
+                        selected={selectedMessageIds.has(message.message_id)}
+                        onSelectedChange={(next) => onMessageSelectionChange(message.message_id, next)}
+                      />
+                    )
+                  })
                 )}
               </div>
             </ScrollArea>
@@ -595,7 +862,7 @@ function AppSidebar(props: {
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">
               <span className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
-                Agent Bus
+                Agent Bus MCP
               </span>
               <div className="truncate text-sm font-medium">Workbench</div>
             </div>
@@ -871,6 +1138,7 @@ export default function App() {
   const topicFindInputRef = useRef<HTMLInputElement | null>(null)
   const tabStripRef = useRef<HTMLDivElement | null>(null)
   const activeTabRef = useRef<HTMLButtonElement | null>(null)
+  const suppressNextFindScrollRef = useRef(false)
 
   const pathnameParts = location.pathname.split("/").filter(Boolean)
   const routeTopicId = pathnameParts[0] === "topics" ? decodeURIComponent(pathnameParts[1] ?? "") : null
@@ -1207,6 +1475,7 @@ export default function App() {
     if (!topicDetail?.focus_message_id) {
       return
     }
+    suppressNextFindScrollRef.current = true
     const element = document.getElementById(`msg-${topicDetail.focus_message_id}`)
     if (!element) {
       return
@@ -1226,6 +1495,12 @@ export default function App() {
     topicDetail && topicFindState.query.trim()
       ? topicDetail.messages.filter((message) => messageContainsText(message, topicFindState.query.trim()))
       : []
+  const activeRailSearchResult =
+    routeTopicId && focusMessageId
+      ? railSearchState.results.find(
+          (result) => result.topic_id === routeTopicId && result.message_id === focusMessageId
+        ) ?? null
+      : null
 
   useEffect(() => {
     setTopicFindState((current) => {
@@ -1240,6 +1515,10 @@ export default function App() {
 
   useEffect(() => {
     if (!topicFindState.open || !topicFindState.query.trim() || topicFindMatches.length === 0) {
+      return
+    }
+    if (suppressNextFindScrollRef.current) {
+      suppressNextFindScrollRef.current = false
       return
     }
     const activeMatch = topicFindMatches[Math.min(topicFindState.activeIndex, topicFindMatches.length - 1)]
@@ -1479,10 +1758,12 @@ export default function App() {
                     </CardContent>
                   </Card>
                 ) : topicDetail ? (
-                  <TopicView
-                    topicDetail={topicDetail}
-                    findState={topicFindState}
-                    findMatches={topicFindMatches}
+        <TopicView
+          topicDetail={topicDetail}
+          activeSearchResult={activeRailSearchResult}
+          sidebarSearchQuery={railSearchState.query}
+          findState={topicFindState}
+          findMatches={topicFindMatches}
                     selectionMode={selectionMode}
                     selectedMessageIds={selectedMessageIds}
                     findInputRef={topicFindInputRef}
@@ -1537,7 +1818,7 @@ export default function App() {
                         aria-hidden="true"
                       />
                       <div className="flex max-w-lg flex-col gap-2">
-                        <h1 className="text-2xl font-medium tracking-tight">Agent Bus Workbench</h1>
+                        <h1 className="text-2xl font-medium tracking-tight">Agent Bus MCP Workbench</h1>
                         <p className="text-muted-foreground">
                           Browse topics by creation or latest activity, keep several threads open at
                           once, and search across the whole bus from the sidebar without leaving the

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface SearchResult {
   created_at?: number
   snippet: string
   rank?: number | null
+  fts_rank?: number | null
   semantic_score?: number | null
   content_markdown?: string | null
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ const EMBEDDING_CACHE_DIR_ENV: &str = "AGENT_BUS_EMBEDDING_CACHE_DIR";
 const FASTEMBED_CACHE_DIR_ENV: &str = "FASTEMBED_CACHE_DIR";
 const XDG_CACHE_HOME_ENV: &str = "XDG_CACHE_HOME";
 const HOME_ENV: &str = "HOME";
+const FTS_SNIPPET_HIGHLIGHT_START: &str = "__AB_HL_START__";
+const FTS_SNIPPET_HIGHLIGHT_END: &str = "__AB_HL_END__";
 
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 #[no_mangle]
@@ -518,7 +520,7 @@ impl CoreDb {
               m.sender,
               m.message_type,
               m.created_at,
-              snippet(messages_fts, 0, '[', ']', '…', 10) AS snippet,
+              snippet(messages_fts, 0, '{highlight_start}', '{highlight_end}', '…', 10) AS snippet,
               bm25(messages_fts) AS rank
               {content_col}
             FROM messages_fts
@@ -528,6 +530,8 @@ impl CoreDb {
             ORDER BY rank ASC
             LIMIT ?
             ",
+            highlight_start = FTS_SNIPPET_HIGHLIGHT_START,
+            highlight_end = FTS_SNIPPET_HIGHLIGHT_END,
             where = where_parts.join(" AND "),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@ const EMBEDDING_CACHE_DIR_ENV: &str = "AGENT_BUS_EMBEDDING_CACHE_DIR";
 const FASTEMBED_CACHE_DIR_ENV: &str = "FASTEMBED_CACHE_DIR";
 const XDG_CACHE_HOME_ENV: &str = "XDG_CACHE_HOME";
 const HOME_ENV: &str = "HOME";
-const FTS_SNIPPET_HIGHLIGHT_START: &str = "__AB_HL_START__";
-const FTS_SNIPPET_HIGHLIGHT_END: &str = "__AB_HL_END__";
+const FTS_SNIPPET_HIGHLIGHT_START: &str = "\u{E000}";
+const FTS_SNIPPET_HIGHLIGHT_END: &str = "\u{E001}";
 
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 #[no_mangle]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -106,4 +106,15 @@ def test_search_messages_hybrid_keeps_fts_snippet_when_semantic_excerpt_omits_qu
     results, _warnings = search_messages(db, query="lambda", topic_id=topic.topic_id, mode="hybrid")
 
     assert results
-    assert "__ab_hl_start__lambda__ab_hl_end__" in results[0]["snippet"].lower()
+    assert "\ue000lambda\ue001" in results[0]["snippet"].lower()
+
+
+def test_snippet_contains_query_terms_ignores_fts_operators() -> None:
+    assert not search_module._snippet_contains_query_terms(
+        "batch or stream handling",
+        query="lambda OR adapter",
+    )
+    assert search_module._snippet_contains_query_terms(
+        "lambda adapter wiring",
+        query="lambda OR adapter",
+    )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import agent_bus.search as search_module
 from agent_bus.db import AgentBusDB
 from agent_bus.search import search_messages
 
@@ -52,3 +53,57 @@ def test_search_messages_hybrid_falls_back_without_embeddings(tmp_path) -> None:
         pytest.skip("FTS5 not available on this SQLite build")
 
     assert results
+
+
+def test_search_messages_hybrid_keeps_fts_snippet_when_semantic_excerpt_omits_query(
+    tmp_path, monkeypatch
+) -> None:
+    db = AgentBusDB(path=str(tmp_path / "bus.sqlite"))
+    topic = db.topic_create(name="pink", metadata=None, mode="new")
+
+    db.sync_once(
+        topic_id=topic.topic_id,
+        agent_name="a",
+        outbox=[
+            {
+                "content_markdown": "Batch event shape details first.\n\nLater we mention lambda adapter wiring.",
+                "message_type": "message",
+            }
+        ],
+        max_items=10,
+        include_self=True,
+        auto_advance=True,
+        ack_through=None,
+    )
+
+    try:
+        fts_results = db.search_messages_fts(query="lambda", topic_id=topic.topic_id, limit=10)
+    except RuntimeError:
+        pytest.skip("FTS5 not available on this SQLite build")
+
+    assert fts_results
+    message = db.get_latest_messages(topic_id=topic.topic_id, limit=1)[0]
+
+    monkeypatch.setattr(
+        search_module,
+        "_semantic_best_by_message",
+        lambda *args, **kwargs: {
+            message.message_id: {
+                "topic_id": topic.topic_id,
+                "topic_name": topic.name,
+                "message_id": message.message_id,
+                "seq": message.seq,
+                "sender": message.sender,
+                "message_type": message.message_type,
+                "created_at": message.created_at,
+                "start_char": 0,
+                "end_char": 24,
+                "semantic_score": 0.9,
+            }
+        },
+    )
+
+    results, _warnings = search_messages(db, query="lambda", topic_id=topic.topic_id, mode="hybrid")
+
+    assert results
+    assert "__ab_hl_start__lambda__ab_hl_end__" in results[0]["snippet"].lower()


### PR DESCRIPTION
## Summary

This PR fixes a set of hybrid search UX/correctness issues in the Agent Bus MCP Web UI.

It makes hybrid results explain themselves more honestly, avoids misleading snippet replacements, and removes the ambiguity between real FTS highlights and literal `[...]` content.

Closes #38.

## What changed

- keep the FTS snippet in hybrid mode when the semantic excerpt drops the query term
- label sidebar results as `hybrid` when both lexical and semantic signals are present
- show hybrid/semantic scores to 4 decimals so near-ties are less misleading
- switch Rust FTS snippet markers from `[` / `]` to internal sentinels so literal `[...]` content is not mistaken for a match
- update the frontend snippet parser to use the new explicit markers
- highlight only actual query terms in the opened message body instead of entire semantic passages
- keep local thread-find highlights visible without stealing the initial scroll from a focused search result

## How to test

- `uv run ruff check agent_bus tests`
- `uv run ty check`
- `uv run pytest tests/test_search.py tests/test_web.py`
- `pnpm --dir frontend test -- App.test.tsx`
- `pnpm --dir frontend build`
- `uv run maturin develop`
- restart `uv run agent-bus serve` after rebuilding so the running process reloads the updated Rust `_core` module

## Notes

- This PR is intentionally scoped to the hybrid search snippet/highlight fix. Other local docs/site changes in the worktree were left out.
- UI previewed locally against the rebuilt Web UI bundle.
