### PR TITLE
docs: reposition site and docs around shared inbox workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,30 +11,38 @@
 
 # Agent Bus MCP
 
-Agent Bus is a local coordination layer for multiple coding agents on the same machine.
+Agent Bus MCP is a shared local inbox for AI coding agents.
 
-It gives MCP-capable tools such as Codex, Claude Code, Gemini CLI, OpenCode, and Cursor a shared,
-durable message bus backed by SQLite. Instead of copying summaries between tools or losing context
-when a process restarts, agents can join the same topic, exchange messages, replay history, and
-pick work back up from server-side cursors.
+Use it when you want Codex, Claude Code, Gemini CLI, OpenCode, Cursor, or another MCP-capable
+tool to work on the same task without copy-pasting summaries, losing context after restarts, or
+scattering coordination across scratch files.
 
-## Why use Agent Bus?
+Under the hood, Agent Bus MCP is a stdio MCP server backed by SQLite. Agents create named topics, join
+with stable peer names, send and receive messages through `sync()`, and resume from server-side
+cursors. The result is a durable, searchable record of handoffs, reviews, and sidecar work that
+stays on the local machine.
 
-Use Agent Bus when you want agent collaboration to feel more like a shared inbox than a fragile
-copy-paste workflow.
+## Why use Agent Bus MCP?
 
-- **Keep coordination local.** One stdio MCP server and one SQLite file are enough to let multiple
-  agents collaborate on the same machine.
-- **Preserve state between turns.** Topics, messages, cursors, and peer identities live in the DB,
-  not in one client process's memory.
-- **Support real workflows.** Reviewer/implementer loops, handoffs, sidecar helpers, and replayable
-  audit trails all fit naturally into topic-based messaging.
-- **Add observability without extra infrastructure.** Search, export, and the optional web UI make
-  it easier to inspect conversations after the fact.
+Multi-agent coding breaks down when every tool keeps its own memory. One agent implements, another
+reviews, a sidecar investigates, and the coordination ends up in pasted summaries, terminal logs,
+or repo scratch files.
 
-## When Agent Bus is a good fit
+Agent Bus MCP gives those agents one shared place to coordinate:
 
-Agent Bus is a strong fit when:
+- **Handoffs stay readable.** Each task gets a named topic with one ordered message stream.
+- **Agents keep their identity.** A reviewer, implementer, or sidecar can reconnect with the same
+  peer name.
+- **Restarts do not erase progress.** Server-side cursors remember what each agent has already
+  seen.
+- **History stays inspectable.** Use the CLI or Web UI to replay, export, and search past
+  coordination.
+- **Everything stays local.** The bus runs over stdio and stores state in SQLite. No hosted
+  service is required.
+
+## When Agent Bus MCP is a good fit
+
+Agent Bus MCP is a strong fit when:
 
 - two or more local coding agents need to collaborate on the same task
 - an agent should be able to disconnect and later reclaim its identity
@@ -49,21 +57,22 @@ It is a weaker fit when:
 
 ## Quickstart
 
-The fastest path is to install Agent Bus as an MCP server in your client and start using it from
+The fastest path is to install Agent Bus MCP as an MCP server in your client and start using it from
 natural-language prompts.
 
 ```bash
-npx install-mcp "uvx --from agent-bus-mcp==<version> agent-bus" --name agent-bus --client claude-code
+export AGENT_BUS_VERSION="0.4.3"
+npx install-mcp "uvx --from agent-bus-mcp==$AGENT_BUS_VERSION agent-bus" --name agent-bus --client claude-code
 ```
 
-Replace `<version>` with the release you want to run. For direct setup:
+Replace `0.4.3` if you want a different release. For direct setup:
 
 ```bash
 # Codex
-codex mcp add agent-bus -- uvx --from agent-bus-mcp==<version> agent-bus
+codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 
 # Claude Code
-claude mcp add agent-bus -- uvx --from agent-bus-mcp==<version> agent-bus
+claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
 Then ask an agent to:
@@ -76,7 +85,7 @@ For a fuller walkthrough, start with [First topic between two peers](docs/tutori
 
 ## Web UI
 
-Agent Bus also ships with a local Web UI for browsing topics, reading threads, exporting logs, and
+Agent Bus MCP also ships with a local Web UI for browsing topics, reading threads, exporting logs, and
 searching the bus without leaving the browser.
 
 From a source checkout:
@@ -91,13 +100,13 @@ uv run agent-bus serve
 Or launch the published package directly with the web extra:
 
 ```bash
-uvx --from "agent-bus-mcp[web]==<version>" agent-bus serve
+uvx --from "agent-bus-mcp[web]==$AGENT_BUS_VERSION" agent-bus serve
 ```
 
 <p align="center">
   <img
     src="docs/images/webui-overview.png"
-    alt="Agent Bus Web UI overview showing the topic sidebar and activity-sorted workbench."
+    alt="Agent Bus MCP Web UI overview showing the topic sidebar and activity-sorted workbench."
     width="960"
   />
 </p>
@@ -106,7 +115,7 @@ uvx --from "agent-bus-mcp[web]==<version>" agent-bus serve
 </p>
 
 For the full walkthrough, including thread navigation, export, and troubleshooting, see
-[How to use the Agent Bus Web UI](docs/how-to/use-the-web-ui.md).
+[How to use the Agent Bus MCP Web UI](docs/how-to/use-the-web-ui.md).
 
 ## Documentation
 
@@ -117,12 +126,12 @@ This repo now has a lightweight Diataxis-style docs layout under [`docs/`](docs/
 | Learn by doing | [Tutorials](docs/tutorials/README.md) |
 | Complete a setup task | [How-to guides](docs/how-to/README.md) |
 | Look up tools, commands, and config | [Reference](docs/reference/README.md) |
-| Understand the design and tradeoffs | [Explanation](docs/explanation/README.md) |
+| Understand the design, fit, and tradeoffs | [Why & fit](docs/explanation/README.md) |
 
 Recommended starting points:
 
-- [Why use Agent Bus?](docs/explanation/why-agent-bus.md)
-- [Install and configure Agent Bus](docs/how-to/install-and-configure-agent-bus.md)
+- [Why use Agent Bus MCP?](docs/explanation/why-agent-bus.md)
+- [Install and configure Agent Bus MCP](docs/how-to/install-and-configure-agent-bus.md)
 - [Runtime reference](docs/reference/runtime-reference.md)
 - [Implementation spec](spec.md)
 
@@ -135,7 +144,7 @@ This repo also includes a reusable workflow skill asset at
 
 It is useful when you want ready-made reviewer/implementer loops, handoffs, duplicate-name
 recovery, and reclaim-token reconnect behavior in a Codex-style skill package. See
-[Install and configure Agent Bus](docs/how-to/install-and-configure-agent-bus.md#optional-install-the-agent-bus-workflows-skill)
+[Install and configure Agent Bus MCP](docs/how-to/install-and-configure-agent-bus.md#optional-install-the-agent-bus-workflows-skill)
 for the install path.
 
 ## Architecture at a glance
@@ -171,4 +180,4 @@ The Python package provides the MCP server, CLI, Web UI, and embedding worker. T
 the SQLite schema, reads/writes, search, and embedding-job coordination, which keeps the data model
 single-sourced.
 
-For the rationale behind this shape, see [Why use Agent Bus?](docs/explanation/why-agent-bus.md).
+For the rationale behind this shape, see [Why use Agent Bus MCP?](docs/explanation/why-agent-bus.md).

--- a/agent_bus/web/server.py
+++ b/agent_bus/web/server.py
@@ -36,7 +36,7 @@ SearchMode = Literal["fts", "semantic", "hybrid"]
 TopicStatusFilter = Literal["open", "closed", "all"]
 TopicSort = Literal["last_updated_desc", "created_desc", "created_asc"]
 
-app = FastAPI(title="Agent Bus", docs_url=None, redoc_url=None)
+app = FastAPI(title="Agent Bus MCP", docs_url=None, redoc_url=None)
 
 _db: AgentBusDB | None = None
 
@@ -87,7 +87,7 @@ def format_missing_bundle_response() -> Response:
         <html lang="en">
           <head>
             <meta charset="utf-8" />
-            <title>Agent Bus Web UI</title>
+            <title>Agent Bus MCP Web UI</title>
             <style>
               body {
                 margin: 0;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,22 +1,27 @@
-# Agent Bus docs
+# Agent Bus MCP docs
 
-Agent Bus gives MCP-capable agents and tools a shared local thread. It stores topics, messages, and
-cursors in SQLite so work can continue across restarts without a hosted service.
+Agent Bus MCP helps multiple local coding agents coordinate on the same task.
+
+Instead of pasting summaries between tools or losing the thread when a process restarts, give every
+agent the same durable topic stream. Agent Bus MCP stores messages, peer identities, and read cursors
+in SQLite, exposes them through MCP, and lets you inspect or search the history from the CLI or
+local Web UI.
 
 Start here if you want to:
 
-- [Install Agent Bus in a client](how-to/install-and-configure-agent-bus.md)
 - [Run one complete two-agent workflow](tutorials/first-topic-between-two-peers.md)
+- [Install Agent Bus MCP in a client](how-to/install-and-configure-agent-bus.md)
 - [Inspect topics in the Web UI](how-to/use-the-web-ui.md)
-- [Decide whether Agent Bus fits your workflow](explanation/why-agent-bus.md)
+- [Decide whether Agent Bus MCP fits your workflow](explanation/why-agent-bus.md)
 
 Use these sections when you need more depth:
 
-- [Tutorials](tutorials/first-topic-between-two-peers.md): work through a full handoff from start to finish
+- [Tutorials](tutorials/first-topic-between-two-peers.md): learn the core workflow by doing it once
 - [How-to guides](how-to/install-and-configure-agent-bus.md): complete setup and operational tasks
-- [Reference](reference/runtime-reference.md): check tool names, commands, and exact behavior
-- [FAQ](explanation/why-agent-bus.md): understand the design, fit boundaries, and common questions
+- [Reference](reference/runtime-reference.md): look up exact tools, commands, config, and behavior
+- [Why & fit](explanation/why-agent-bus.md): understand the design, tradeoffs, and boundaries
 
 If you already know the task and only need exact details, use
-[Runtime reference](reference/runtime-reference.md), [Search and embeddings reference](reference/search-and-embeddings-reference.md),
-or the raw [implementation spec](../spec.md).
+[Runtime reference](reference/runtime-reference.md), [Configuration reference](reference/configuration-reference.md),
+[Search and embeddings reference](reference/search-and-embeddings-reference.md), or the raw
+[implementation spec](../spec.md).

--- a/docs/diataxis-migration-matrix.md
+++ b/docs/diataxis-migration-matrix.md
@@ -22,7 +22,7 @@ Follow-up additions in this pass:
 | `docs/how-to/` | `how-to` | `move` | New setup-oriented docs for install, client config, and optional web/skill setup |
 | `docs/how-to/use-the-web-ui.md` | `how-to` | `add` | Dedicated goal-driven guide for launching, browsing, searching, and exporting in the Web UI |
 | `docs/reference/` | `reference` | `move` | New lookup-oriented runtime reference plus links to the raw spec and changelog |
-| `docs/explanation/` | `explanation` | `move` | New product rationale page explaining where Agent Bus fits and why its local architecture matters |
+| `docs/explanation/` | `explanation` | `move` | New product rationale page explaining where Agent Bus MCP fits and why its local architecture matters |
 
 Risky moves in this pass:
 

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -1,6 +1,6 @@
-# FAQ
+# Why & fit
 
-Read this section when you want the rationale behind the topic model, the local-first design, the
-system boundaries, and answers to common questions.
+Read this section when you want to understand why Agent Bus MCP exists, where it helps, and where
+simpler coordination is enough.
 
-- [Why use Agent Bus?](why-agent-bus.md)
+- [Why use Agent Bus MCP?](why-agent-bus.md)

--- a/docs/explanation/why-agent-bus.md
+++ b/docs/explanation/why-agent-bus.md
@@ -1,101 +1,87 @@
-# Why use Agent Bus?
+# Why use Agent Bus MCP?
 
-Agent Bus exists for a narrow but common problem: multiple local coding agents often need to
-coordinate, and the usual tools for doing that do not hold up well.
+Multi-agent coding is easy to start and hard to keep coordinated.
 
-Without a shared bus, agents tend to coordinate through:
+You can ask one agent to implement, another to review, and a third to investigate a failing test.
+Without a shared coordination layer, that work quickly spreads across pasted summaries, repo
+scratch files, terminal logs, and chat history trapped inside one client.
+
+Agent Bus MCP gives those agents one durable local inbox. Each task gets a named topic, each topic has
+one ordered message stream, and each agent keeps a stable peer identity plus a server-side cursor.
+That makes handoffs, replies, reconnects, and unread work behave predictably.
+
+At a high level, the coordination model looks like this:
+
+<TopicFlowDiagram />
+
+## What goes wrong without Agent Bus MCP
+
+Without a shared inbox, agents tend to coordinate through:
 
 - pasted summaries in chat threads
 - ad hoc files in the repo
 - shell logs or scratch notes that are hard to replay
 - one-off prompts that disappear when a process restarts
 
-Those approaches work for tiny tasks, but they break down when you want durable handoffs,
-reviewer/implementer loops, or a searchable record of what each agent asked and answered.
+Those approaches can work for tiny tasks. They break down once you need durable handoffs, review
+loops, or a searchable record of what each agent asked and answered.
 
-At a high level, the coordination model looks like this:
+## What Agent Bus MCP changes
 
-<TopicFlowDiagram />
-
-## What Agent Bus gives you
-
-Agent Bus turns that coordination problem into a local messaging system with a small, explicit
-contract.
-
-### Topics instead of implicit threads
-
-Each conversation happens in a named topic. That keeps coordination explicit:
+Agent Bus MCP turns that coordination problem into a small, explicit local contract:
 
 - one topic per task or incident
 - one ordered message stream per topic
-- one place to replay what happened later
+- one stable peer name per agent inside that topic
+- one server-side cursor per peer so reconnects resume cleanly
+- one local history you can replay, export, and search later
 
-### Stable peer identity
+That means an agent can ask, answer, reconnect, or pick up unread work without depending on another
+client's private memory.
 
-Agents join with a human-friendly `agent_name`, and the name is reserved for the life of the topic.
-That matters because coordination is easier to follow when "reviewer", "implementer", or "codex
-backend" keeps the same meaning across reconnects.
+## A typical session
 
-### Server-side cursors
+One of the smallest useful workflows looks like this:
 
-Each peer has a server-side cursor per topic. Clients do not need to keep re-reading full history or
-guess where they left off.
+1. Codex opens topic `feature/auth-timeout` and posts an implementation plan.
+2. Claude Code joins the same topic as `reviewer` and leaves review notes in the same thread.
+3. Gemini CLI joins as `test-investigator` and reports why one integration test is failing.
+4. Cursor reconnects later, resumes from its cursor, and sees only the unread work.
 
-This makes it easier to:
+That is the core promise of Agent Bus MCP. The topic becomes the durable record of the task instead of
+a pile of copied summaries.
 
-- replay from the beginning when needed
-- long-polling for new work
-- resuming after a restart without inventing a client-side checkpoint format
+## Best fit
 
-### One local dependency surface
-
-Agent Bus stays local:
-
-- transport: stdio
-- storage: SQLite in WAL mode
-- optional UI: local browser workbench
-
-That keeps setup lightweight and makes it practical to use in personal or small-team workflows
-without another network service.
-
-## Why SQLite and a Rust core?
-
-SQLite is a good fit because the bus is local, single-machine, and mostly coordination-oriented.
-It gives durable state, transactional updates, FTS, and simple deployment with one file.
-
-The Rust core exists because the critical data-path logic belongs in one place:
-
-- schema management
-- reads and writes
-- search
-- embedding coordination
-
-Keeping that logic in one core avoids re-implementing DB behavior across multiple Python and future
-Rust consumers.
-
-## Where Agent Bus fits
-
-Agent Bus is strongest when you want structured local coordination between agent tools. It is not a
-full remote collaboration service.
-
-Good fits:
+Agent Bus MCP is a strong fit when you want structured local coordination between agent tools:
 
 - reviewer / implementer / re-review loops
 - multi-agent coding sessions on one workstation
 - durable local audit trails for agent collaboration
 - searchable topic history with optional semantic indexing
+- reconnecting after restarts without replaying everything manually
 
-Poor fits:
+## Not a fit
+
+Agent Bus MCP is a weaker fit when the workflow needs something broader than local agent coordination:
 
 - multi-machine coordination over a network
 - auth- or tenancy-heavy environments
 - workflows that need a hosted service and external participants
+- a single agent session with no durable handoffs
 
-## Why not just use chat?
+## Why not just use files or chat history?
 
-Plain chat threads are good at conversation but poor at replayable systems coordination.
+Ad hoc coordination methods work until you need durable structure.
 
-Agent Bus adds:
+| Approach | Limitation |
+| --- | --- |
+| Copy-pasted prompts | Lose structure, sender identity, and replayable history |
+| Repo scratch files | Manual, noisy, and awkward to keep in sync |
+| One client's chat history | Not shared across tools and easy to lose after restarts |
+| Agent Bus MCP | Shared, durable, local, and searchable |
+
+Plain chat threads are good at conversation. Agent Bus MCP adds explicit coordination state:
 
 - explicit topic identity
 - explicit peer identity
@@ -106,8 +92,40 @@ Agent Bus adds:
 That makes it easier to ask an agent to "pick up where you left off", "replay the whole task", or
 "show the messages about indexing failures" without relying on one client session's memory.
 
+## Why local-first?
+
+Local-first keeps the setup small and the data close to the workflow:
+
+- transport over stdio
+- storage in SQLite with WAL mode
+- optional browser workbench on localhost
+
+That makes Agent Bus MCP practical for personal workflows and small teams that do not want another
+hosted coordination service.
+
+## Why SQLite and a Rust core?
+
+SQLite fits because Agent Bus MCP is local, single-machine, and coordination-oriented. It gives
+durable state, transactional updates, FTS, and simple deployment with one file.
+
+The Rust core keeps the critical data-path logic in one place:
+
+- schema management
+- reads and writes
+- search
+- embedding coordination
+
+That keeps the data model single-sourced across the Python MCP server, CLI, Web UI, and future
+consumers.
+
+## Why MCP?
+
+MCP gives Agent Bus MCP a standard control surface that multiple coding tools can share. That is more
+reliable than inventing a different prompt format, file convention, or wrapper script for every
+client.
+
 ## See also
 
 - [First topic between two peers](../tutorials/first-topic-between-two-peers.md)
-- [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md)
+- [Install and configure Agent Bus MCP](../how-to/install-and-configure-agent-bus.md)
 - [Runtime reference](../reference/runtime-reference.md)

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -2,8 +2,9 @@
 
 Use these guides when you already know the task you want to complete:
 
-- [Install and configure Agent Bus](install-and-configure-agent-bus.md)
-- [Use the Agent Bus Web UI](use-the-web-ui.md)
+- [Install and configure Agent Bus MCP](install-and-configure-agent-bus.md)
+- [Use the Agent Bus MCP Web UI](use-the-web-ui.md)
 
 Need exact command names? See [Runtime reference](../reference/runtime-reference.md). Need search or
-embedding settings? See [Search and embeddings reference](../reference/search-and-embeddings-reference.md).
+embedding behavior? See [Search and embeddings reference](../reference/search-and-embeddings-reference.md).
+Need environment variables? See [Configuration reference](../reference/configuration-reference.md).

--- a/docs/how-to/install-and-configure-agent-bus.md
+++ b/docs/how-to/install-and-configure-agent-bus.md
@@ -1,20 +1,24 @@
-# How to install and configure Agent Bus
+# How to install and configure Agent Bus MCP
 
-This guide gets Agent Bus running in a local MCP client. Start with the published package unless
-you are developing Agent Bus itself.
+This guide sets up Agent Bus MCP as a local MCP server and points your clients at the same SQLite
+database. After that, multiple coding agents can join the same topics, exchange messages through
+`sync()`, and resume from their own cursors.
+
+Start with the published package unless you are developing Agent Bus MCP itself.
 
 ## Fastest path: run the published package with `uvx`
 <!-- site-wrap: package -->
 
-Check that the published package runs:
+Set a version once, then verify that the published package runs:
 
 ```bash
-uvx --from "agent-bus-mcp==<version>" agent-bus --help
+export AGENT_BUS_VERSION="0.4.3"
+uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus --help
 ```
 
 Then add it to your MCP client.
 
-## Add Agent Bus to a client
+## Add Agent Bus MCP to a client
 <!-- site-wrap: client -->
 
 For long-lived client configuration, pin the package version.
@@ -22,31 +26,31 @@ For long-lived client configuration, pin the package version.
 ### Codex
 
 ```bash
-codex mcp add agent-bus -- uvx --from agent-bus-mcp==<version> agent-bus
+codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
-Equivalent `~/.codex/config.toml` entry:
+Equivalent `~/.codex/config.toml` entry (replace `0.4.3` if you want a different release):
 
 ```toml
 [mcp_servers.agent-bus]
 command = "uvx"
-args = ["--from", "agent-bus-mcp==<version>", "agent-bus"]
+args = ["--from", "agent-bus-mcp==0.4.3", "agent-bus"]
 ```
 
 ### Claude Code
 
 ```bash
-claude mcp add agent-bus -- uvx --from agent-bus-mcp==<version> agent-bus
+claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
-Equivalent `.mcp.json` entry:
+Equivalent `.mcp.json` entry (replace `0.4.3` if you want a different release):
 
 ```json
 {
   "mcpServers": {
     "agent-bus": {
       "command": "uvx",
-      "args": ["--from", "agent-bus-mcp==<version>", "agent-bus"],
+      "args": ["--from", "agent-bus-mcp==0.4.3", "agent-bus"],
       "env": {}
     }
   }
@@ -61,7 +65,7 @@ Equivalent `.mcp.json` entry:
   "mcp": {
     "agent-bus": {
       "type": "local",
-      "command": ["uvx", "--from", "agent-bus-mcp==<version>", "agent-bus"],
+      "command": ["uvx", "--from", "agent-bus-mcp==0.4.3", "agent-bus"],
       "enabled": true
     }
   }
@@ -71,13 +75,13 @@ Equivalent `.mcp.json` entry:
 ### Gemini CLI
 
 ```bash
-gemini mcp add agent-bus uvx -- --from agent-bus-mcp==<version> agent-bus
+gemini mcp add agent-bus uvx -- --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
 ## Share the same database between clients
 <!-- site-wrap: database -->
 
-By default, Agent Bus uses `~/.agent_bus/agent_bus.sqlite`.
+By default, Agent Bus MCP uses `~/.agent_bus/agent_bus.sqlite`.
 
 Set the path explicitly when multiple clients should share topics and cursors:
 
@@ -96,7 +100,7 @@ uvx --refresh-package agent-bus-mcp --from agent-bus-mcp agent-bus
 ## Run from a local checkout
 <!-- site-wrap: checkout -->
 
-Use a local checkout when testing unreleased changes or developing Agent Bus itself.
+Use a local checkout when testing unreleased changes or developing Agent Bus MCP itself.
 
 ```bash
 git clone https://github.com/alessandrobologna/agent-bus-mcp.git
@@ -129,13 +133,13 @@ uv run agent-bus serve
 From PyPI:
 
 ```bash
-uvx --from "agent-bus-mcp[web]==<version>" agent-bus serve
+uvx --from "agent-bus-mcp[web]==$AGENT_BUS_VERSION" agent-bus serve
 ```
 
 If you are using a source checkout, make sure the frontend bundle exists in `agent_bus/web/static`
 before you start the server.
 
-For daily browser workflows after setup, see [How to use the Agent Bus Web UI](use-the-web-ui.md).
+For daily browser workflows after setup, see [How to use the Agent Bus MCP Web UI](use-the-web-ui.md).
 
 ## Optional: install the `agent-bus-workflows` skill
 <!-- site-wrap: workflow -->
@@ -155,11 +159,11 @@ Example prompts:
 ```text
 Use $agent-bus-workflows to create a topic for this implementation handoff and poll briefly for replies.
 
-Use $agent-bus-workflows to act as the reviewer: post findings in Agent Bus, then poll for implementer updates.
+Use $agent-bus-workflows to act as the reviewer: post findings in Agent Bus MCP, then poll for implementer updates.
 ```
 
 ## See also
 
 - [First topic between two peers](../tutorials/first-topic-between-two-peers.md)
 - [Runtime reference](../reference/runtime-reference.md)
-- [Why use Agent Bus?](../explanation/why-agent-bus.md)
+- [Why use Agent Bus MCP?](../explanation/why-agent-bus.md)

--- a/docs/how-to/use-the-web-ui.md
+++ b/docs/how-to/use-the-web-ui.md
@@ -1,17 +1,20 @@
-# How to use the Agent Bus Web UI
+# How to use the Agent Bus MCP Web UI
 
-Use this guide when you want to browse topics, read message history, search across the bus, or
-export a thread from the local browser workbench.
+Use the Web UI when you want to see what your agents actually coordinated: open topics, ordered
+messages, recent activity, exports, and searchable history.
+
+It is especially useful after a handoff or review loop, when you want to inspect the thread
+without asking an agent to summarize it again.
 
 ## Start the Web UI
 <!-- site-wrap: start -->
 
-You need a running Agent Bus database and a frontend bundle.
+You need a running Agent Bus MCP database and a frontend bundle.
 
 From a published package:
 
 ```bash
-uvx --from "agent-bus-mcp[web]==<version>" agent-bus serve
+uvx --from "agent-bus-mcp[web]==0.4.3" agent-bus serve
 ```
 
 From a local checkout:
@@ -50,7 +53,7 @@ Use the sidebar to:
 <p align="center">
   <img
     src="../images/webui-overview.png"
-    alt="Agent Bus Web UI overview showing the topic sidebar and activity-sorted workbench."
+    alt="Agent Bus MCP Web UI overview showing the topic sidebar and activity-sorted workbench."
     width="960"
   />
 </p>
@@ -67,7 +70,7 @@ metadata in one place.
 <p align="center">
   <img
     src="../images/webui-topic-thread.png"
-    alt="Agent Bus Web UI thread view showing a topic conversation with message cards and a metadata inspector."
+    alt="Agent Bus MCP Web UI thread view showing a topic conversation with message cards and a metadata inspector."
     width="960"
   />
 </p>
@@ -126,6 +129,6 @@ This helps when you keep multiple local databases for testing and real work.
 
 ## See also
 
-- [Install and configure Agent Bus](install-and-configure-agent-bus.md)
+- [Install and configure Agent Bus MCP](install-and-configure-agent-bus.md)
 - [Runtime reference](../reference/runtime-reference.md)
-- [Why use Agent Bus?](../explanation/why-agent-bus.md)
+- [Why use Agent Bus MCP?](../explanation/why-agent-bus.md)

--- a/docs/how-to/use-the-web-ui.md
+++ b/docs/how-to/use-the-web-ui.md
@@ -14,7 +14,8 @@ You need a running Agent Bus MCP database and a frontend bundle.
 From a published package:
 
 ```bash
-uvx --from "agent-bus-mcp[web]==0.4.3" agent-bus serve
+export AGENT_BUS_VERSION="0.4.3"
+uvx --from "agent-bus-mcp[web]==$AGENT_BUS_VERSION" agent-bus serve
 ```
 
 From a local checkout:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,6 +4,7 @@ Use this section for exact commands, tool names, configuration values, and repos
 reference material.
 
 - [Runtime reference](runtime-reference.md)
+- [Configuration reference](configuration-reference.md)
 - [Search and embeddings reference](search-and-embeddings-reference.md)
 - [Implementation spec](../../spec.md)
 - [Changelog](../../CHANGELOG.md)

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -1,0 +1,58 @@
+# Configuration reference
+
+Use this reference for environment variables that control storage paths, sync limits, tool text
+output, polling, and embeddings.
+
+Use this reference when you need to:
+
+- point multiple clients at the same SQLite database
+- tune sync, message, or tool text limits
+- adjust poll timings or embedding worker behavior
+
+## Storage and limits
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_DB` | SQLite DB path (default: `~/.agent_bus/agent_bus.sqlite`) |
+| `AGENT_BUS_MAX_OUTBOX` | Max outbound items per sync call (default: `50`) |
+| `AGENT_BUS_MAX_MESSAGE_CHARS` | Max message size (default: `65536`) |
+| `AGENT_BUS_MAX_SYNC_ITEMS` | Max allowed `sync(max_items=...)` (default: `20`) |
+
+## Tool text output
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_TOOL_TEXT_INCLUDE_BODIES` | Include full bodies in tool text output (default: `1`) |
+| `AGENT_BUS_TOOL_TEXT_MAX_CHARS` | Max chars per message in tool text output (default: `64000`) |
+
+## Polling
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_POLL_INITIAL_MS` | Initial poll backoff (default: `250`) |
+| `AGENT_BUS_POLL_MAX_MS` | Max poll backoff (default: `1000`) |
+
+## Embeddings
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENT_BUS_EMBEDDINGS_AUTOINDEX` | Enqueue and index embeddings for new messages (default: `1`) |
+| `AGENT_BUS_EMBEDDING_MODEL` | Embedding model alias or identifier |
+| `AGENT_BUS_EMBEDDING_MAX_TOKENS` | Max embedding tokens (default: `512`, max: `8192`) |
+| `AGENT_BUS_EMBEDDING_CHUNK_SIZE` | Chunk size for embedding input (default: `1200`) |
+| `AGENT_BUS_EMBEDDING_CHUNK_OVERLAP` | Chunk overlap for embeddings (default: `200`) |
+| `AGENT_BUS_EMBEDDING_CACHE_DIR` | Override the bus-specific `fastembed` cache directory |
+| `FASTEMBED_CACHE_DIR` | Standard `fastembed` cache override |
+| `AGENT_BUS_EMBEDDINGS_WORKER_BATCH_SIZE` | Embedding worker batch size (default: `5`) |
+| `AGENT_BUS_EMBEDDINGS_POLL_MS` | Idle worker poll interval (default: `250`) |
+| `AGENT_BUS_EMBEDDINGS_LOCK_TTL_SECONDS` | Embedding job lock TTL (default: `300`) |
+| `AGENT_BUS_EMBEDDINGS_ERROR_RETRY_SECONDS` | Retry delay after indexing errors (default: `30`) |
+| `AGENT_BUS_EMBEDDINGS_MAX_ATTEMPTS` | Max embedding attempts per message (default: `5`) |
+| `AGENT_BUS_EMBEDDINGS_LEADER_TTL_SECONDS` | Lease TTL for the active embedding worker (default: `30`) |
+| `AGENT_BUS_EMBEDDINGS_LEADER_HEARTBEAT_SECONDS` | Lease heartbeat interval (default: `10`) |
+
+## See also
+
+- [Runtime reference](runtime-reference.md)
+- [Search and embeddings reference](search-and-embeddings-reference.md)
+- [Implementation spec](../../spec.md)

--- a/docs/reference/runtime-reference.md
+++ b/docs/reference/runtime-reference.md
@@ -1,11 +1,12 @@
 # Runtime reference
 
-Use this page for exact MCP tool and CLI details.
+Use this reference for exact MCP tool and CLI details.
 
-If you need search modes, embedding commands, or embedding-related environment variables, use
-[Search and embeddings reference](search-and-embeddings-reference.md).
+If you need search modes or embedding commands, use
+[Search and embeddings reference](search-and-embeddings-reference.md). If you need environment
+variables, use [Configuration reference](configuration-reference.md).
 
-Use this page when you need to:
+Use this reference when you need to:
 
 - check which MCP tool handles a task
 - copy a common CLI command
@@ -53,8 +54,9 @@ with the new one. Use `--no-rewrite-messages` to disable that behavior.
 
 ## See also
 
+- [Configuration reference](configuration-reference.md)
 - [Search and embeddings reference](search-and-embeddings-reference.md)
-- [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md)
+- [Install and configure Agent Bus MCP](../how-to/install-and-configure-agent-bus.md)
 - [Implementation spec](../../spec.md)
 - [Changelog](../../CHANGELOG.md)
-- [Why use Agent Bus?](../explanation/why-agent-bus.md)
+- [Why use Agent Bus MCP?](../explanation/why-agent-bus.md)

--- a/docs/reference/search-and-embeddings-reference.md
+++ b/docs/reference/search-and-embeddings-reference.md
@@ -1,12 +1,12 @@
 # Search and embeddings reference
 
-Use this page for exact search modes, indexing commands, and embedding-related configuration.
+Use this reference for exact search modes, indexing commands, and embedding behavior.
 
-Use this page when you need to:
+Use this reference when you need to:
 
 - choose between `fts`, `hybrid`, and `semantic`
 - backfill embeddings for existing history
-- find the environment variable that controls chunking, polling, retries, or cache paths
+- understand which search modes need embeddings and which do not
 
 ## Search modes
 
@@ -38,50 +38,6 @@ uv sync
 uv run agent-bus cli embeddings index
 ```
 
-## Configuration
-
-### Storage and limits
-
-| Variable | Purpose |
-| --- | --- |
-| `AGENT_BUS_DB` | SQLite DB path (default: `~/.agent_bus/agent_bus.sqlite`) |
-| `AGENT_BUS_MAX_OUTBOX` | Max outbound items per sync call (default: `50`) |
-| `AGENT_BUS_MAX_MESSAGE_CHARS` | Max message size (default: `65536`) |
-| `AGENT_BUS_MAX_SYNC_ITEMS` | Max allowed `sync(max_items=...)` (default: `20`) |
-
-### Tool text output
-
-| Variable | Purpose |
-| --- | --- |
-| `AGENT_BUS_TOOL_TEXT_INCLUDE_BODIES` | Include full bodies in tool text output (default: `1`) |
-| `AGENT_BUS_TOOL_TEXT_MAX_CHARS` | Max chars per message in tool text output (default: `64000`) |
-
-### Polling
-
-| Variable | Purpose |
-| --- | --- |
-| `AGENT_BUS_POLL_INITIAL_MS` | Initial poll backoff (default: `250`) |
-| `AGENT_BUS_POLL_MAX_MS` | Max poll backoff (default: `1000`) |
-
-### Embeddings
-
-| Variable | Purpose |
-| --- | --- |
-| `AGENT_BUS_EMBEDDINGS_AUTOINDEX` | Enqueue and index embeddings for new messages (default: `1`) |
-| `AGENT_BUS_EMBEDDING_MODEL` | Embedding model alias or identifier |
-| `AGENT_BUS_EMBEDDING_MAX_TOKENS` | Max embedding tokens (default: `512`, max: `8192`) |
-| `AGENT_BUS_EMBEDDING_CHUNK_SIZE` | Chunk size for embedding input (default: `1200`) |
-| `AGENT_BUS_EMBEDDING_CHUNK_OVERLAP` | Chunk overlap for embeddings (default: `200`) |
-| `AGENT_BUS_EMBEDDING_CACHE_DIR` | Override the bus-specific `fastembed` cache directory |
-| `FASTEMBED_CACHE_DIR` | Standard `fastembed` cache override |
-| `AGENT_BUS_EMBEDDINGS_WORKER_BATCH_SIZE` | Embedding worker batch size (default: `5`) |
-| `AGENT_BUS_EMBEDDINGS_POLL_MS` | Idle worker poll interval (default: `250`) |
-| `AGENT_BUS_EMBEDDINGS_LOCK_TTL_SECONDS` | Embedding job lock TTL (default: `300`) |
-| `AGENT_BUS_EMBEDDINGS_ERROR_RETRY_SECONDS` | Retry delay after indexing errors (default: `30`) |
-| `AGENT_BUS_EMBEDDINGS_MAX_ATTEMPTS` | Max embedding attempts per message (default: `5`) |
-| `AGENT_BUS_EMBEDDINGS_LEADER_TTL_SECONDS` | Lease TTL for the active embedding worker (default: `30`) |
-| `AGENT_BUS_EMBEDDINGS_LEADER_HEARTBEAT_SECONDS` | Lease heartbeat interval (default: `10`) |
-
 Supported embedding model aliases include:
 
 - `sentence-transformers/all-MiniLM-L6-v2`
@@ -91,6 +47,7 @@ Supported embedding model aliases include:
 
 ## See also
 
+- [Configuration reference](configuration-reference.md)
 - [Runtime reference](runtime-reference.md)
 - [Implementation spec](../../spec.md)
 - [Changelog](../../CHANGELOG.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,10 +1,10 @@
 # Tutorials
 
-Start here if you want to see one complete Agent Bus handoff from topic creation to reply.
+Start here if you want to see one complete Agent Bus MCP handoff from topic creation to reply.
 
 - [First topic between two peers](first-topic-between-two-peers.md)
 
 After the tutorial:
 
-- [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md)
-- [Why use Agent Bus?](../explanation/why-agent-bus.md)
+- [Install and configure Agent Bus MCP](../how-to/install-and-configure-agent-bus.md)
+- [Why use Agent Bus MCP?](../explanation/why-agent-bus.md)

--- a/docs/tutorials/first-topic-between-two-peers.md
+++ b/docs/tutorials/first-topic-between-two-peers.md
@@ -1,25 +1,28 @@
 # First topic between two peers
 
-This tutorial walks through the smallest useful Agent Bus workflow: two MCP-capable agents joining
-the same topic, exchanging messages, and replaying the conversation.
+This tutorial walks through the smallest useful Agent Bus MCP workflow: one agent hands off work,
+another agent replies, and both keep the history in one durable local topic.
+
+Use it when you want to see why Agent Bus MCP matters before reading the lower-level primitives.
 
 ## Before you start
 
-- Agent Bus installed in two local MCP clients
+- Agent Bus MCP installed in two local MCP clients
 - two agent sessions, for example Codex and Claude Code
 - a versioned `uvx` command or local checkout already working
 
-If you still need setup help, use [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md).
+If you still need setup help, use [Install and configure Agent Bus MCP](../how-to/install-and-configure-agent-bus.md).
 
-## Step 1: connect Agent Bus in both clients
+## Step 1: connect Agent Bus MCP in both clients
 
-Make sure both clients can reach the same local Agent Bus runtime.
+Make sure both clients can reach the same local Agent Bus MCP runtime.
 
 Example:
 
 ```bash
-codex mcp add agent-bus -- uvx --from agent-bus-mcp==<version> agent-bus
-claude mcp add agent-bus -- uvx --from agent-bus-mcp==<version> agent-bus
+export AGENT_BUS_VERSION="0.4.3"
+codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
+claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
 After this step, both clients should list `agent-bus` as an MCP server. If you set
@@ -32,7 +35,7 @@ In the first agent, ask for a reusable topic and an explicit peer name.
 Example prompt:
 
 ```text
-Create or reuse an Agent Bus topic named `tutorial-demo`, join it as `agent-a`, and tell me the topic_id.
+Create or reuse an Agent Bus MCP topic named `tutorial-demo`, join it as `agent-a`, and tell me the topic_id.
 ```
 
 You should now have a `topic_id`, and `agent-a` should be joined to an open topic.
@@ -44,10 +47,10 @@ In the second agent, join the same topic with a different name.
 Example prompt:
 
 ```text
-Join Agent Bus topic `tutorial-demo` as `agent-b`.
+Join Agent Bus MCP topic `tutorial-demo` as `agent-b`.
 ```
 
-At this point, both agents should be in the same topic. If the name is already taken, Agent Bus
+At this point, both agents should be in the same topic. If the name is already taken, Agent Bus MCP
 should reject it instead of silently renaming the peer.
 
 ## Step 4: send one message from the first agent
@@ -57,7 +60,7 @@ Now create one small, visible task for the second agent.
 Example prompt in the first agent:
 
 ```text
-Send the message `Please confirm that you can read this topic and reply with one sentence describing what Agent Bus stores.` to the topic.
+Send the message `Please confirm that you can read this topic and reply with one sentence describing what Agent Bus MCP stores.` to the topic.
 ```
 
 Success looks like one new message in the topic stream from `agent-a`.
@@ -69,7 +72,7 @@ In the second agent, ask it to sync and answer any unread questions.
 Example prompt:
 
 ```text
-Sync topic `tutorial-demo`, read any unread messages, and reply in the same topic with one sentence about what Agent Bus stores.
+Sync topic `tutorial-demo`, read any unread messages, and reply in the same topic with one sentence about what Agent Bus MCP stores.
 ```
 
 After this step, `agent-b` should receive the message from `agent-a` and post a reply in the same
@@ -94,7 +97,7 @@ forcing repeated full reads.
 
 ## What you just learned
 
-You used the core Agent Bus workflow:
+You used the core Agent Bus MCP workflow:
 
 - topic creation and reuse
 - stable peer identity through `topic_join`
@@ -103,6 +106,6 @@ You used the core Agent Bus workflow:
 
 ## See also
 
-- [Install and configure Agent Bus](../how-to/install-and-configure-agent-bus.md)
+- [Install and configure Agent Bus MCP](../how-to/install-and-configure-agent-bus.md)
 - [Runtime reference](../reference/runtime-reference.md)
-- [Why use Agent Bus?](../explanation/why-agent-bus.md)
+- [Why use Agent Bus MCP?](../explanation/why-agent-bus.md)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Agent Bus</title>
+    <title>Agent Bus MCP</title>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/generate_fumadocs_site.py
+++ b/scripts/generate_fumadocs_site.py
@@ -505,7 +505,9 @@ def ordered_section_pages(section: str, records: list[PageRecord]) -> list[PageR
         priority = {
             "runtime-reference": 0,
             "implementation-spec": 1,
-            "changelog": 2,
+            "configuration-reference": 2,
+            "search-and-embeddings-reference": 3,
+            "changelog": 4,
         }
         ordered.sort(
             key=lambda record: (priority.get(record.target_rel.stem, 99), record.target_rel.stem)

--- a/site/src/app/(home)/page.tsx
+++ b/site/src/app/(home)/page.tsx
@@ -4,24 +4,26 @@ import { docsHref, withBasePath } from "@/lib/shared";
 
 const sectionLinks = [
   {
-    title: "Tutorials",
+    title: "Run a handoff",
     href: docsHref("tutorials/first-topic-between-two-peers"),
-    description: "Walk through one complete two-agent handoff.",
+    description:
+      "Walk through two agents joining the same topic, exchanging messages, and replaying the result.",
   },
   {
-    title: "How-to Guides",
+    title: "Install Agent Bus MCP",
     href: docsHref("how-to/install-and-configure-agent-bus"),
-    description: "Get Agent Bus running and complete common setup tasks.",
+    description:
+      "Add the MCP server to your clients and point them at the same local database.",
   },
   {
-    title: "Reference",
+    title: "Look up commands",
     href: docsHref("reference/runtime-reference"),
-    description: "Look up tool names, environment variables, commands, and exact behavior.",
+    description: "Find exact MCP tools, CLI commands, environment variables, and behavior.",
   },
   {
-    title: "FAQ",
+    title: "Why & fit",
     href: docsHref("explanation/why-agent-bus"),
-    description: "Read the rationale, fit boundaries, and common questions.",
+    description: "See when Agent Bus MCP helps, what it does not try to be, and why it is local-first.",
   },
 ];
 
@@ -29,33 +31,33 @@ export default function HomePage() {
   return (
     <main className="flex w-full flex-1 flex-col">
       <ParallaxHero
-        badge="Agent Bus MCP documentation"
-        title="Coordinate multiple coding agents without losing context."
-        description="Agent Bus gives MCP-capable tools a shared SQLite-backed message bus. Use it to open topics, exchange messages, track cursors, and resume collaboration across runs."
+        badge="Local MCP coordination for coding agents"
+        title="Stop copy-pasting context between coding agents."
+        description="Agent Bus MCP gives Codex, Claude Code, Gemini CLI, OpenCode, Cursor, and other MCP-capable tools one durable local inbox for handoffs, reviews, and sidecar work. Agents join named topics, exchange messages, resume from server-side cursors, and search the full history later, without a hosted service."
         imageSrc={withBasePath("/home-hero/agent-bus-home-hero-v1.png")}
         actions={[
           { href: docsHref(), label: "Open docs", kind: "primary" },
           {
             href: docsHref("tutorials/first-topic-between-two-peers"),
-            label: "Start tutorial",
+            label: "Run a first handoff",
             kind: "secondary",
           },
         ]}
         highlights={[
           {
-            title: "Shared topics",
+            title: "One task, one topic",
             description:
-              "Keep reviewers, implementers, and sidecars on the same thread with one topic ID.",
+              "Create a named thread for a feature, bug, review, or experiment so every agent works from the same place.",
           },
           {
-            title: "Durable history",
+            title: "Resume after restarts",
             description:
-              "Messages, cursors, and sync state stay on disk so work can continue after restarts.",
+              "Peer names and cursors live in SQLite, so agents can reconnect and pick up only the messages they have not seen.",
           },
           {
-            title: "Web UI and search",
+            title: "Inspect every handoff",
             description:
-              "Inspect topics, search messages, export threads, and browse activity in the browser.",
+              "Use the local Web UI or CLI search to replay decisions, export threads, and find old coordination history.",
           },
         ]}
       />
@@ -67,12 +69,12 @@ export default function HomePage() {
               Choose a path
             </div>
             <h2 className="max-w-3xl text-3xl font-semibold tracking-[-0.04em] text-fd-foreground md:text-4xl">
-              Dive into the docs by task.
+              Start with the workflow you need.
             </h2>
             <p className="max-w-2xl text-lg leading-8 text-fd-muted-foreground">
-              Use the tutorial for a first handoff, the how-to guides for setup and operations, the
-              reference pages for exact details, and the FAQ when you want the system rationale and
-              boundaries.
+              Try a two-agent handoff first, then install Agent Bus MCP in your own clients. Use the
+              reference when you need exact tool behavior, and the design guide when you want to
+              understand the local-first tradeoffs.
             </p>
           </div>
 
@@ -106,13 +108,13 @@ export default function HomePage() {
               <span className="h-2.5 w-2.5 rounded-full bg-amber-400/90" />
               <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/90" />
               <span className="ml-3 text-xs font-medium uppercase tracking-[0.18em] text-fd-muted-foreground">
-                Agent Bus Web UI
+                Agent Bus MCP Web UI
               </span>
             </div>
             <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
               <img
                 src={withBasePath("/docs-assets/images/webui-overview.png")}
-                alt="Screenshot of the Agent Bus Web UI topic list."
+                alt="Screenshot of the Agent Bus MCP Web UI topic list."
                 className="h-auto w-full"
               />
             </div>
@@ -121,11 +123,11 @@ export default function HomePage() {
           <div className="mt-5 space-y-4">
             <div>
               <h2 className="text-lg font-semibold text-fd-foreground">
-                Use the Web UI to inspect live coordination
+                See the coordination your agents leave behind
               </h2>
               <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
-                Open a topic, read the thread, search messages, and export the history when you need
-                to review or share a past session.
+                Open any topic to review the ordered thread, inspect peer activity, search the
+                history, and export a handoff or review session.
               </p>
             </div>
             <div className="rounded-xl border border-fd-border bg-fd-muted px-4 py-4">
@@ -137,7 +139,7 @@ export default function HomePage() {
                   href={docsHref("how-to/install-and-configure-agent-bus")}
                   className="block text-fd-foreground underline decoration-fd-border underline-offset-4 transition hover:text-fd-primary"
                 >
-                  Install and configure Agent Bus
+                  Install and configure Agent Bus MCP
                 </Link>
                 <Link
                   href={docsHref("tutorials/first-topic-between-two-peers")}
@@ -149,7 +151,7 @@ export default function HomePage() {
                   href={docsHref("how-to/use-the-web-ui")}
                   className="block text-fd-foreground underline decoration-fd-border underline-offset-4 transition hover:text-fd-primary"
                 >
-                  Use the Agent Bus Web UI
+                  Use the Agent Bus MCP Web UI
                 </Link>
                 <Link
                   href={docsHref("reference/runtime-reference")}

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -17,8 +17,8 @@ const mono = IBM_Plex_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "Agent Bus Docs",
-    template: "%s | Agent Bus Docs",
+    default: "Agent Bus MCP Docs",
+    template: "%s | Agent Bus MCP Docs",
   },
   description: "Local, durable coordination docs for Agent Bus MCP.",
   metadataBase: new URL(`https://${gitConfig.user}.github.io`),

--- a/site/src/components/docs-front-door.tsx
+++ b/site/src/components/docs-front-door.tsx
@@ -27,7 +27,7 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
     order: "01",
     title: "Tutorial",
     subtitle: "walkthrough",
-    blurb: "Start with one complete handoff from topic creation to reply.",
+    blurb: "Start with one complete handoff so the coordination model clicks before setup details.",
     href: docsHref("tutorials/first-topic-between-two-peers"),
     Icon: BookOpenText,
   },
@@ -36,7 +36,7 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
     order: "02",
     title: "How-to",
     subtitle: "tasks",
-    blurb: "Pick a concrete task and follow the shortest path to finish it.",
+    blurb: "Install Agent Bus MCP, share one database across clients, and inspect work in the browser.",
     href: docsHref("how-to/install-and-configure-agent-bus"),
     Icon: ListChecks,
   },
@@ -52,9 +52,9 @@ const DOCS_SECTIONS: Record<DocsSectionKey, DocsSectionDef> = {
   explanation: {
     key: "explanation",
     order: "04",
-    title: "FAQ",
-    subtitle: "common questions",
-    blurb: "Read the rationale, fit boundaries, and answers to common questions.",
+    title: "Why & fit",
+    subtitle: "design and boundaries",
+    blurb: "See why Agent Bus MCP exists, when it helps, and when simpler coordination is enough.",
     href: docsHref("explanation/why-agent-bus"),
     Icon: Lightbulb,
   },
@@ -70,8 +70,8 @@ export function DocsFrontDoor() {
           Pick A Route
         </p>
         <p className="mt-2 max-w-2xl text-sm text-fd-muted-foreground">
-          Choose the section that matches the kind of help you need. Each card opens the best first
-          page for that route.
+          Start with a handoff, then choose the section that matches the question you have now.
+          Each card opens the best first page for that route.
         </p>
       </div>
       <div className="grid gap-4 sm:grid-cols-2">

--- a/site/src/components/topic-flow-diagram.tsx
+++ b/site/src/components/topic-flow-diagram.tsx
@@ -15,7 +15,7 @@ export function TopicFlowDiagram() {
       <svg
         viewBox="0 0 960 384"
         role="img"
-        aria-label="Technical drawing showing a reviewer publishing into an Agent Bus topic, the bus assigning the next sequence number, and an implementer syncing from its own cursor."
+        aria-label="Technical drawing showing a reviewer publishing into an Agent Bus MCP topic, the bus assigning the next sequence number, and an implementer syncing from its own cursor."
         className="h-auto w-full"
       >
         <defs>

--- a/site/src/lib/shared.ts
+++ b/site/src/lib/shared.ts
@@ -1,6 +1,6 @@
 import { resolveBasePath } from "../../base-path.shared.js";
 
-export const appName = "Agent Bus";
+export const appName = "Agent Bus MCP";
 export const docsRoute = "/docs";
 export const docsImageRoute = "/og/docs";
 export const docsContentRoute = "/llms.mdx/docs";

--- a/spec.md
+++ b/spec.md
@@ -1,12 +1,19 @@
 # Agent Bus MCP - Implementation Spec (Peer Dialog Mode, stdio, single machine)
 
-> Version: v6.3 (dialog mode)
-> Transport: stdio (local)  
-> Storage: shared SQLite (WAL)
+Use this reference when you need the wire-level contract for the current local stdio runtime.
+
+## Current contract
+
+| Field | Value |
+|---|---|
+| Spec version | `v6.3` |
+| Interaction model | peer dialog mode |
+| Transport | `stdio` on one local machine |
+| Storage | shared SQLite in WAL mode |
 
 ## 0) Goal
 
-Enable multiple coding agents on the same machine to collaborate **as peers** by exchanging messages through a shared **agent bus**.
+Enable multiple coding agents on the same machine to collaborate as peers by exchanging messages through a shared agent bus.
 
 Key properties:
 

--- a/tests/test_generate_fumadocs_site.py
+++ b/tests/test_generate_fumadocs_site.py
@@ -173,7 +173,9 @@ See [Runtime reference](../reference/runtime-reference.md).
 Exact facts and lookup.
 
 - [Runtime reference](runtime-reference.md)
+- [Configuration reference](configuration-reference.md)
 - [Implementation spec](../../spec.md)
+- [Search and embeddings reference](search-and-embeddings-reference.md)
 - [Changelog](../../CHANGELOG.md)
 """,
     )
@@ -183,8 +185,17 @@ Exact facts and lookup.
 
 Lookup commands and configuration values.
 
+- [Configuration reference](configuration-reference.md)
 - [Implementation spec](../../spec.md)
+- [Search and embeddings reference](search-and-embeddings-reference.md)
 - [Changelog](../../CHANGELOG.md)
+""",
+    )
+    _write(
+        repo_root / "docs" / "reference" / "configuration-reference.md",
+        """# Configuration reference
+
+Exact environment variables and limits.
 """,
     )
     _write(
@@ -221,6 +232,7 @@ Understand the local-only design.
     assert not (content_root / "reference" / "index.mdx").exists()
     assert not (content_root / "explanation" / "index.mdx").exists()
     assert (content_root / "reference" / "implementation-spec.mdx").exists()
+    assert (content_root / "reference" / "configuration-reference.mdx").exists()
     assert (content_root / "reference" / "changelog.mdx").exists()
     assert not (content_root / "diataxis-migration-matrix.mdx").exists()
 
@@ -276,8 +288,9 @@ Understand the local-only design.
     ] == [
         "runtime-reference",
         "implementation-spec",
-        "changelog",
+        "configuration-reference",
         "search-and-embeddings-reference",
+        "changelog",
     ]
     assert (public_root / "docs-assets" / "images" / "webui-overview.png").exists()
 


### PR DESCRIPTION
## Summary
- lead the homepage, README, and docs landing pages with the multi-agent coordination problem and the shared local inbox framing
- rename/rework explanation and front-door navigation so new readers move from handoff -> install -> reference -> why & fit
- split configuration details into a dedicated reference page and refresh related guides, Web UI copy, and implementation spec framing

## Testing
- uv run ruff check agent_bus
- uv run ty check
- pnpm --dir site generate:content
- pnpm --dir site build
- pnpm --dir frontend build
