### PR TITLE
ci: publish docs site from custom-domain root

### DIFF
--- a/.github/workflows/publish-docs-site.yml
+++ b/.github/workflows/publish-docs-site.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   NODE_VERSION: "24"
+  NEXT_PUBLIC_BASE_PATH: ""
 
 jobs:
   build:

--- a/.github/workflows/publish-docs-site.yml
+++ b/.github/workflows/publish-docs-site.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   NODE_VERSION: "24"
   NEXT_PUBLIC_BASE_PATH: ""
+  SITE_ORIGIN: "https://www.agentbusmcp.com"
 
 jobs:
   build:

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Manrope } from "next/font/google";
 import { Provider } from "@/components/provider";
-import { gitConfig } from "@/lib/shared";
+import { siteOrigin } from "@/lib/shared";
 import "./global.css";
 
 const sans = Manrope({
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     template: "%s | Agent Bus MCP Docs",
   },
   description: "Local, durable coordination docs for Agent Bus MCP.",
-  metadataBase: new URL(`https://${gitConfig.user}.github.io`),
+  metadataBase: new URL(siteOrigin),
 };
 
 export default function Layout({ children }: LayoutProps<"/">) {

--- a/site/src/lib/shared.ts
+++ b/site/src/lib/shared.ts
@@ -11,6 +11,11 @@ export const gitConfig = {
   branch: "main",
 };
 
+export const siteOrigin = (process.env.SITE_ORIGIN ?? "https://www.agentbusmcp.com").replace(
+  /\/+$/,
+  "",
+);
+
 export const basePath = resolveBasePath({
   explicit: process.env.NEXT_PUBLIC_BASE_PATH,
 });


### PR DESCRIPTION
## Summary
- force the Pages publish build to use an empty `NEXT_PUBLIC_BASE_PATH`
- keep custom-domain deploys rooted at `/` instead of `/${GITHUB_REPOSITORY##*/}`
- avoid `/_next`, font, image, and docs asset 404s on `www.agentbusmcp.com`

## Why
The publish workflow was building the site with an inferred base path of `/agent-bus-mcp` in GitHub Actions. That is correct for project Pages URLs, but wrong for the configured custom domain `www.agentbusmcp.com`, where assets need to be published from the domain root.

## Testing
- `NEXT_PUBLIC_BASE_PATH="" pnpm --dir site build`
- inspected `site/out/index.html` to confirm asset URLs use `/_next/...`, `/docs-assets/...`, and `/docs/...` rather than `/agent-bus-mcp/...`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-docs-site.yml"); puts "YAML OK"'`