### PR TITLE
web: add thread map for topic navigation

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -284,6 +284,13 @@ function setTopicThreadLayout(props: {
   viewport!.dispatchEvent(new Event("scroll"))
 }
 
+function revealThreadMapOverlay() {
+  const hotspot = document.querySelector<HTMLElement>("[data-ab-thread-map-hotspot='true']")
+  expect(hotspot).toBeTruthy()
+  fireEvent.pointerEnter(hotspot!)
+  fireEvent.pointerMove(hotspot!)
+}
+
 function topicStream(topicId: string) {
   const EventSourceCtor = globalThis.EventSource as unknown as {
     instances: Array<{ url: string; emit: (type: string, payload?: unknown) => void }>
@@ -574,7 +581,7 @@ describe("App", () => {
     )
   })
 
-  test("shows a shared Map and Inspector rail for overflowing desktop topics", async () => {
+  test("keeps the inspector in the rail and reveals the thread-map overlay from the hotspot", async () => {
     setDesktopWidth()
 
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
@@ -607,9 +614,63 @@ describe("App", () => {
       messageHeights: [220, 260, 180, 240],
     })
 
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
-    expect(screen.getByRole("tab", { name: "Inspector" })).toBeInTheDocument()
-    expect(screen.getByText("Click a marker to jump to that message.")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("Topic metadata")).toBeInTheDocument())
+    expect(screen.queryByRole("tab", { name: "Map" })).not.toBeInTheDocument()
+    expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "false")
+
+    revealThreadMapOverlay()
+
+    await waitFor(() =>
+      expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "true")
+    )
+  })
+
+  test("auto-hides the thread-map overlay after pointer inactivity", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", [
+            "alpha section one",
+            "alpha section two",
+            "alpha section three",
+            "alpha section four",
+          ])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("alpha section one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1400,
+      clientHeight: 420,
+      messageHeights: [220, 260, 180, 240],
+    })
+
+    await waitFor(() =>
+      expect(document.querySelector("[data-ab-thread-map-hotspot='true']")).toBeTruthy()
+    )
+
+    revealThreadMapOverlay()
+
+    expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "true")
+
+    await new Promise((resolve) => window.setTimeout(resolve, 1900))
+
+    await waitFor(() =>
+      expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "false")
+    )
   })
 
   test("uses stable sender tones for default thread-map markers", async () => {
@@ -719,11 +780,11 @@ describe("App", () => {
       messageHeights: [140, 140],
     })
 
-    await waitFor(() => expect(screen.queryByRole("tab", { name: "Map" })).not.toBeInTheDocument())
+    await waitFor(() => expect(document.querySelector("[data-ab-thread-map='true']")).toBeNull())
     expect(screen.getByText("Topic metadata")).toBeInTheDocument()
   })
 
-  test("clicking a thread-map marker jumps to its message", async () => {
+  test("clicking a thread-map marker band jumps to its message", async () => {
     setDesktopWidth()
 
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
@@ -751,15 +812,83 @@ describe("App", () => {
       messageHeights: [200, 220, 240],
     })
 
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+    await waitFor(() => expect(document.querySelector("[data-ab-thread-map='true']")).toBeInTheDocument())
+    revealThreadMapOverlay()
 
     const target = document.getElementById("msg-t-1-m-2")
     expect(target).toBeTruthy()
     const scrollSpy = vi.spyOn(target!, "scrollIntoView").mockImplementation(() => {})
+    const markerBand = screen.getByRole("button", { name: /Jump to message #2 by architect/i })
 
-    fireEvent.click(screen.getByRole("button", { name: /Jump to message #2 by architect/i }))
+    expect(Number.parseFloat(markerBand.style.height)).toBeGreaterThan(10)
+    expect(markerBand.style.height).toContain("%")
+
+    fireEvent.click(markerBand)
 
     expect(scrollSpy).toHaveBeenCalled()
+  })
+
+  test("dragging the thread-map viewport scrolls the thread", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", ["first drag target", "second drag target", "third drag target"])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("first drag target")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1200,
+      clientHeight: 300,
+      messageHeights: [240, 260, 280],
+    })
+
+    await waitFor(() => expect(document.querySelector("[data-ab-thread-map='true']")).toBeInTheDocument())
+    revealThreadMapOverlay()
+
+    const mapFrame = document.querySelector<HTMLElement>("[data-ab-thread-map-frame='true']")
+    expect(mapFrame).toBeTruthy()
+    vi.spyOn(mapFrame!, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: 300,
+      right: 100,
+      width: 100,
+      height: 300,
+      toJSON: () => {},
+    } as DOMRect)
+
+    const viewport = document.querySelector<HTMLElement>(
+      "[data-ab-topic-thread-scroll-area='true'] [data-slot='scroll-area-viewport']"
+    )
+    expect(viewport).toBeTruthy()
+    expect(viewport!.scrollTop).toBe(0)
+
+    const cursor = document.querySelector<HTMLElement>("[data-ab-thread-map-viewport='true']")
+    expect(cursor).toBeTruthy()
+    cursor!.setPointerCapture = vi.fn()
+    cursor!.releasePointerCapture = vi.fn()
+
+    fireEvent.pointerDown(cursor!, { button: 0, pointerId: 1, clientY: 15 })
+    fireEvent.pointerMove(cursor!, { pointerId: 1, clientY: 165 })
+    fireEvent.pointerUp(cursor!, { pointerId: 1, clientY: 165 })
+
+    expect(viewport!.scrollTop).toBeGreaterThan(0)
   })
 
   test("updates thread-map marker states from local thread find", async () => {
@@ -794,7 +923,7 @@ describe("App", () => {
       messageHeights: [190, 190, 190],
     })
 
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+    await waitFor(() => expect(document.querySelector("[data-ab-thread-map='true']")).toBeInTheDocument())
 
     fireEvent.keyDown(window, { key: "f", metaKey: true })
     fireEvent.change(await screen.findByPlaceholderText(/Find in this thread/i), {
@@ -910,12 +1039,8 @@ describe("App", () => {
       messageHeights: [260, 260],
     })
 
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
-
-    fireEvent.mouseDown(screen.getByRole("tab", { name: "Inspector" }))
-    await waitFor(() =>
-      expect(screen.getByRole("tab", { name: "Inspector" })).toHaveAttribute("aria-selected", "true")
-    )
+    await waitFor(() => expect(document.querySelector("[data-ab-thread-map='true']")).toBeInTheDocument())
+    expect(screen.getByText("Topic metadata")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: /Load earlier/i }))
     expect(await screen.findByText("earlier one")).toBeInTheDocument()
@@ -926,11 +1051,6 @@ describe("App", () => {
       messageHeights: [200, 200, 260, 260],
     })
 
-    await waitFor(() =>
-      expect(screen.getByRole("tab", { name: "Inspector" })).toHaveAttribute("aria-selected", "true")
-    )
-
-    fireEvent.mouseDown(screen.getByRole("tab", { name: "Map" }))
     await waitFor(() =>
       expect(document.querySelectorAll("[data-ab-thread-map-marker]")).toHaveLength(4)
     )
@@ -972,7 +1092,7 @@ describe("App", () => {
       instances: Array<unknown>
     }
 
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+    await waitFor(() => expect(document.querySelector("[data-ab-thread-map='true']")).toBeInTheDocument())
     const initialObserverCount = ResizeObserverCtor.instances.length
 
     topicStream("t-1").emit("topic.update", {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -80,6 +80,60 @@ function topicDetail(
   }
 }
 
+function topicDetailWithMessages(
+  topicId: string,
+  contents: string[],
+  options?: {
+    focusMessageId?: string | null
+    hasEarlier?: boolean
+    startSeq?: number
+    messageIds?: string[]
+  }
+): TopicDetailResponse {
+  const startSeq = options?.startSeq ?? 1
+  const messages = contents.map((content, index) => {
+    const seq = startSeq + index
+    return {
+      message_id: options?.messageIds?.[index] ?? `${topicId}-m-${seq}`,
+      topic_id: topicId,
+      seq,
+      sender: index % 2 === 0 ? "reviewer" : "architect",
+      message_type: "message" as const,
+      reply_to: null,
+      reply_to_sender: null,
+      content_markdown: content,
+      metadata: null,
+      client_message_id: null,
+      created_at: 1_700_000_100 + index,
+    }
+  })
+
+  return {
+    topic: {
+      ...topicsPayload.topics.find((topic) => topic.topic_id === topicId)!,
+      message_count: messages.length,
+      last_seq: messages.at(-1)?.seq ?? 0,
+      last_message_at: messages.at(-1)?.created_at ?? null,
+      last_updated_at: messages.at(-1)?.created_at ?? 1_700_000_100,
+    },
+    messages,
+    message_count: messages.length,
+    first_seq: messages[0]?.seq ?? null,
+    last_seq: messages.at(-1)?.seq ?? null,
+    has_earlier: options?.hasEarlier ?? false,
+    context_mode: Boolean(options?.focusMessageId),
+    focus_message_id: options?.focusMessageId ?? null,
+    presence: [
+      {
+        topic_id: topicId,
+        agent_name: "codex reviewer",
+        last_seq: messages.at(-1)?.seq ?? 0,
+        updated_at: 1_700_000_110,
+      },
+    ],
+  }
+}
+
 function jsonResponse(payload: unknown) {
   return Promise.resolve(
     new Response(JSON.stringify(payload), {
@@ -159,6 +213,75 @@ function renderAppWithControls(initialEntries: string[]) {
       </MemoryRouter>
     </TooltipProvider>
   )
+}
+
+function setDesktopWidth(width = 1440) {
+  window.innerWidth = width
+  window.dispatchEvent(new Event("resize"))
+}
+
+function triggerResizeObservers() {
+  const ResizeObserverCtor = globalThis.ResizeObserver as unknown as {
+    instances: Array<{ trigger: () => void }>
+  }
+
+  for (const observer of ResizeObserverCtor.instances) {
+    observer.trigger()
+  }
+}
+
+function setTopicThreadLayout(props: {
+  scrollHeight: number
+  clientHeight: number
+  scrollTop?: number
+  messageHeights?: number[]
+  messageGap?: number
+}) {
+  const {
+    scrollHeight,
+    clientHeight,
+    scrollTop = 0,
+    messageHeights = [],
+    messageGap = 12,
+  } = props
+
+  const scrollAreaRoot = document.querySelector<HTMLElement>("[data-ab-topic-thread-scroll-area='true']")
+  expect(scrollAreaRoot).toBeTruthy()
+
+  const viewport = scrollAreaRoot!.querySelector<HTMLElement>("[data-slot='scroll-area-viewport']")
+  expect(viewport).toBeTruthy()
+
+  Object.defineProperty(viewport!, "scrollHeight", {
+    configurable: true,
+    value: scrollHeight,
+  })
+  Object.defineProperty(viewport!, "clientHeight", {
+    configurable: true,
+    value: clientHeight,
+  })
+  Object.defineProperty(viewport!, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: scrollTop,
+  })
+
+  let offset = 0
+  const messageNodes = Array.from(document.querySelectorAll<HTMLElement>("[data-ab-message-id]"))
+  for (const [index, node] of messageNodes.entries()) {
+    const height = messageHeights[index] ?? 180
+    Object.defineProperty(node, "offsetTop", {
+      configurable: true,
+      value: offset,
+    })
+    Object.defineProperty(node, "offsetHeight", {
+      configurable: true,
+      value: height,
+    })
+    offset += height + messageGap
+  }
+
+  triggerResizeObservers()
+  viewport!.dispatchEvent(new Event("scroll"))
 }
 
 function topicStream(topicId: string) {
@@ -448,6 +571,386 @@ describe("App", () => {
           (element) => element.textContent === "alpha"
         )
       ).toBe(true)
+    )
+  })
+
+  test("shows a shared Map and Inspector rail for overflowing desktop topics", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", [
+            "alpha section one",
+            "alpha section two",
+            "alpha section three",
+            "alpha section four",
+          ])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("alpha section one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1400,
+      clientHeight: 420,
+      messageHeights: [220, 260, 180, 240],
+    })
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+    expect(screen.getByRole("tab", { name: "Inspector" })).toBeInTheDocument()
+    expect(screen.getByText("Click a marker to jump to that message.")).toBeInTheDocument()
+  })
+
+  test("keeps thread-map markers out of the normal tab order", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", [
+            "alpha section one",
+            "alpha section two",
+            "alpha section three",
+          ])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("alpha section one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1300,
+      clientHeight: 360,
+      messageHeights: [220, 220, 220],
+    })
+
+    await waitFor(() =>
+      expect(
+        document.querySelector<HTMLElement>("[data-ab-thread-map-marker='t-1-m-1']")
+      ).toHaveAttribute("tabindex", "-1")
+    )
+  })
+
+  test("keeps the inspector-only rail for desktop topics without overflow", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(topicDetailWithMessages("t-1", ["short one", "short two"]))
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("short one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 400,
+      clientHeight: 400,
+      messageHeights: [140, 140],
+    })
+
+    await waitFor(() => expect(screen.queryByRole("tab", { name: "Map" })).not.toBeInTheDocument())
+    expect(screen.getByText("Topic metadata")).toBeInTheDocument()
+  })
+
+  test("clicking a thread-map marker jumps to its message", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", ["first jump target", "second jump target", "third jump target"])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("first jump target")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1300,
+      clientHeight: 380,
+      messageHeights: [200, 220, 240],
+    })
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+
+    const target = document.getElementById("msg-t-1-m-2")
+    expect(target).toBeTruthy()
+    const scrollSpy = vi.spyOn(target!, "scrollIntoView").mockImplementation(() => {})
+
+    fireEvent.click(screen.getByRole("button", { name: /Jump to message #2 by architect/i }))
+
+    expect(scrollSpy).toHaveBeenCalled()
+  })
+
+  test("updates thread-map marker states from local thread find", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", [
+            "alpha one",
+            "alpha two",
+            "plain context",
+          ])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("alpha one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1200,
+      clientHeight: 360,
+      messageHeights: [190, 190, 190],
+    })
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true })
+    fireEvent.change(await screen.findByPlaceholderText(/Find in this thread/i), {
+      target: { value: "alpha" },
+    })
+
+    setTopicThreadLayout({
+      scrollHeight: 1200,
+      clientHeight: 360,
+      messageHeights: [190, 190, 190],
+    })
+
+    const firstMarker = document.querySelector<HTMLElement>("[data-ab-thread-map-marker='t-1-m-1']")
+    const secondMarker = document.querySelector<HTMLElement>("[data-ab-thread-map-marker='t-1-m-2']")
+
+    await waitFor(() => {
+      expect(firstMarker).toHaveAttribute("data-local-matched", "true")
+      expect(firstMarker).toHaveAttribute("data-local-active", "true")
+      expect(secondMarker).toHaveAttribute("data-local-matched", "true")
+      expect(secondMarker).toHaveAttribute("data-local-active", "false")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+
+    await waitFor(() => {
+      expect(firstMarker).toHaveAttribute("data-local-active", "false")
+      expect(secondMarker).toHaveAttribute("data-local-active", "true")
+    })
+  })
+
+  test("shows the focused-message marker for route-driven focus navigation", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1" && url.searchParams.get("focus") === "focused-message") {
+        return jsonResponse(
+          topicDetailWithMessages(
+            "t-1",
+            ["focused detail", "background context"],
+            {
+              focusMessageId: "focused-message",
+              messageIds: ["focused-message", "t-1-m-2"],
+            }
+          )
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1?focus=focused-message"])
+
+    expect(await screen.findByText("focused detail")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1100,
+      clientHeight: 320,
+      messageHeights: [210, 210],
+    })
+
+    await waitFor(() =>
+      expect(
+        document.querySelector<HTMLElement>("[data-ab-thread-map-marker='focused-message']")
+      ).toHaveAttribute("data-focused", "true")
+    )
+  })
+
+  test("recomputes the thread map after loading earlier messages without losing the selected rail", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", ["later one", "later two"], {
+            hasEarlier: true,
+            startSeq: 101,
+          })
+        )
+      }
+      if (url.pathname === "/api/topics/t-1/messages" && url.searchParams.get("before_seq") === "101") {
+        const earlier = topicDetailWithMessages("t-1", ["earlier one", "earlier two"], {
+          startSeq: 1,
+        }).messages
+
+        return jsonResponse({
+          messages: earlier,
+          first_seq: earlier[0]?.seq ?? null,
+          last_seq: earlier[earlier.length - 1]?.seq ?? null,
+          has_earlier: false,
+        })
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("later one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1200,
+      clientHeight: 360,
+      messageHeights: [260, 260],
+    })
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Inspector" }))
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Inspector" })).toHaveAttribute("aria-selected", "true")
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Load earlier/i }))
+    expect(await screen.findByText("earlier one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1800,
+      clientHeight: 360,
+      messageHeights: [200, 200, 260, 260],
+    })
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Inspector" })).toHaveAttribute("aria-selected", "true")
+    )
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Map" }))
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-ab-thread-map-marker]")).toHaveLength(4)
+    )
+  })
+
+  test("does not recreate thread-map observers on presence-only stream updates", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", [
+            "alpha section one",
+            "alpha section two",
+            "alpha section three",
+          ])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("alpha section one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1300,
+      clientHeight: 360,
+      messageHeights: [220, 220, 220],
+    })
+
+    const ResizeObserverCtor = globalThis.ResizeObserver as unknown as {
+      instances: Array<unknown>
+    }
+
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Map" })).toBeInTheDocument())
+    const initialObserverCount = ResizeObserverCtor.instances.length
+
+    topicStream("t-1").emit("topic.update", {
+      topic_id: "t-1",
+      last_seq: 3,
+      message_count: 3,
+      presence: [
+        {
+          topic_id: "t-1",
+          agent_name: "presence probe",
+          last_seq: 3,
+          updated_at: 1_700_000_330,
+        },
+      ],
+    })
+
+    await waitFor(() => expect(screen.getAllByText("presence probe").length).toBeGreaterThan(0))
+
+    await waitFor(() =>
+      expect(ResizeObserverCtor.instances.length).toBe(initialObserverCount)
     )
   })
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter, useNavigate } from "react-router-dom"
 import { describe, expect, test, vi } from "vitest"
 
@@ -662,15 +662,21 @@ describe("App", () => {
       expect(document.querySelector("[data-ab-thread-map-hotspot='true']")).toBeTruthy()
     )
 
-    revealThreadMapOverlay()
+    vi.useFakeTimers()
 
-    expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "true")
+    try {
+      revealThreadMapOverlay()
 
-    await new Promise((resolve) => window.setTimeout(resolve, 1900))
+      expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "true")
 
-    await waitFor(() =>
+      await act(async () => {
+        vi.advanceTimersByTime(1900)
+      })
+
       expect(document.querySelector("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "false")
-    )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test("uses stable sender tones for default thread-map markers", async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -612,6 +612,48 @@ describe("App", () => {
     expect(screen.getByText("Click a marker to jump to that message.")).toBeInTheDocument()
   })
 
+  test("uses stable sender tones for default thread-map markers", async () => {
+    setDesktopWidth()
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = new URL(String(input), "http://localhost")
+
+      if (url.pathname === "/api/topics") {
+        return jsonResponse(topicsPayload)
+      }
+      if (url.pathname === "/api/topics/t-1") {
+        return jsonResponse(
+          topicDetailWithMessages("t-1", [
+            "alpha section one",
+            "alpha section two",
+            "alpha section three",
+            "alpha section four",
+          ])
+        )
+      }
+
+      throw new Error(`Unhandled fetch ${url.pathname}${url.search}`)
+    })
+
+    renderApp(["/topics/t-1"])
+
+    expect(await screen.findByText("alpha section one")).toBeInTheDocument()
+
+    setTopicThreadLayout({
+      scrollHeight: 1400,
+      clientHeight: 420,
+      messageHeights: [220, 260, 180, 240],
+    })
+
+    await waitFor(() => {
+      const firstMarker = document.querySelector<HTMLElement>("[data-ab-thread-map-marker='t-1-m-1']")
+      const secondMarker = document.querySelector<HTMLElement>("[data-ab-thread-map-marker='t-1-m-2']")
+      expect(firstMarker).toHaveAttribute("data-sender-tone")
+      expect(secondMarker).toHaveAttribute("data-sender-tone")
+      expect(firstMarker?.getAttribute("data-sender-tone")).not.toBe(secondMarker?.getAttribute("data-sender-tone"))
+    })
+  })
+
   test("keeps thread-map markers out of the normal tab order", async () => {
     setDesktopWidth()
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -645,11 +645,11 @@ function ThreadMap(props: {
         data-ab-thread-map="true"
         className="relative min-h-72 flex-1 overflow-hidden rounded-md border border-border bg-background/80"
       >
-        <div className="absolute inset-3 rounded-sm border border-dashed border-border/80" />
-        <div className="absolute inset-y-3 left-1/2 w-px -translate-x-1/2 bg-border/80" />
+        <div className="absolute inset-y-3 left-1/2 w-16 -translate-x-1/2 rounded-full border border-border/70 bg-muted/30 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]" />
+        <div className="absolute inset-y-4 left-1/2 w-px -translate-x-1/2 bg-border/80" />
         {viewport ? (
           <div
-            className="pointer-events-none absolute inset-x-2 rounded-md border border-primary/60 bg-primary/12 shadow-[0_0_0_1px_rgba(255,255,255,0.02)]"
+            className="pointer-events-none absolute left-1/2 w-20 -translate-x-1/2 rounded-xl border border-primary/45 bg-primary/10 shadow-[0_0_0_1px_rgba(255,255,255,0.02)]"
             style={{
               top: `${clamp(viewport.top * 100, 0, 100)}%`,
               height: `${clamp(viewport.height * 100, 8, 100)}%`,
@@ -657,13 +657,17 @@ function ThreadMap(props: {
           />
         ) : null}
         {markers.map((marker) => {
+          const center = clamp((marker.top + marker.height / 2) * 100, 0, 100)
+          const visibleWidth = marker.localActive ? 20 : marker.focused ? 16 : marker.localMatched ? 14 : 10
+          const visibleHeight = marker.localActive ? 12 : marker.focused ? 10 : marker.localMatched ? 9 : 8
+          const hitAreaHeight = Math.max(visibleHeight + 6, 14)
           const toneClass = marker.localActive
-            ? "bg-sky-400 shadow-[0_0_0_1px_rgba(125,211,252,0.35)]"
+            ? "border-sky-300/90 bg-sky-300 shadow-[0_0_0_4px_rgba(56,189,248,0.14)]"
             : marker.localMatched
-              ? "bg-cyan-300/85"
+              ? "border-cyan-300/80 bg-cyan-300/90"
               : marker.focused
-                ? "bg-primary"
-                : "bg-zinc-500/70"
+                ? "border-primary/80 bg-primary"
+                : "border-border/70 bg-zinc-400/85"
           const stateLabel = marker.localActive
             ? "active find match"
             : marker.localMatched
@@ -683,14 +687,22 @@ function ThreadMap(props: {
               data-local-active={marker.localActive ? "true" : "false"}
               aria-current={marker.localActive ? "true" : undefined}
               aria-label={`Jump to message #${marker.seq} by ${marker.sender} (${stateLabel})`}
-              className="absolute inset-x-2 rounded-full transition-transform hover:scale-y-110 focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:outline-none"
+              className="absolute left-1/2 -translate-x-1/2 rounded-full transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:outline-none"
               style={{
-                top: `${clamp(marker.top * 100, 0, 100)}%`,
-                height: `${clamp(marker.height * 100, marker.localActive ? 1.4 : 0.75, 12)}%`,
+                top: `calc(${center}% - ${hitAreaHeight / 2}px)`,
+                height: `${hitAreaHeight}px`,
+                width: "36px",
               }}
               onClick={() => onJumpToMessage(marker.messageId)}
             >
-              <span className={`block h-full w-full rounded-full ${toneClass}`} />
+              <span
+                className={`mx-auto block rounded-full border ${toneClass}`}
+                style={{
+                  width: `${visibleWidth}px`,
+                  height: `${visibleHeight}px`,
+                  marginTop: `${(hitAreaHeight - visibleHeight) / 2}px`,
+                }}
+              />
             </button>
           )
         })}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -669,7 +669,11 @@ function ThreadMap(props: {
 }) {
   const { markers, viewport, visible, onJumpToMessage, onViewportDrag } = props
   const mapRef = useRef<HTMLDivElement | null>(null)
-  const dragStateRef = useRef<{ grabOffset: number; viewportHeight: number } | null>(null)
+  const dragStateRef = useRef<{
+    actualViewportHeight: number
+    grabOffset: number
+    renderedViewportHeight: number
+  } | null>(null)
   const senderTones = useMemo(() => {
     const tones = new Map<string, ThreadMapSenderTone>()
     for (const marker of markers) {
@@ -693,8 +697,11 @@ function ThreadMap(props: {
     }
 
     const pointerTop = (clientY - rect.top) / rect.height
-    const maxTop = Math.max(1 - dragState.viewportHeight, 0)
-    onViewportDrag(clamp(pointerTop - dragState.grabOffset, 0, maxTop))
+    const renderedMaxTop = Math.max(1 - dragState.renderedViewportHeight, 0)
+    const renderedTop = clamp(pointerTop - dragState.grabOffset, 0, renderedMaxTop)
+    const actualMaxTop = Math.max(1 - dragState.actualViewportHeight, 0)
+    const actualTop = renderedMaxTop > 0 ? (renderedTop / renderedMaxTop) * actualMaxTop : 0
+    onViewportDrag(clamp(actualTop, 0, actualMaxTop))
   }
 
   const renderedViewport = viewport
@@ -739,14 +746,14 @@ function ThreadMap(props: {
                 return
               }
 
-              const viewportHeight = renderedViewport.height
               dragStateRef.current = {
+                actualViewportHeight: viewport ? clamp(viewport.height, 0, 1) : renderedViewport.height,
                 grabOffset: clamp(
                   (event.clientY - rect.top) / rect.height - renderedViewport.top,
                   0,
-                  viewportHeight
+                  renderedViewport.height
                 ),
-                viewportHeight,
+                renderedViewportHeight: renderedViewport.height,
               }
               event.currentTarget.setPointerCapture(event.pointerId)
               event.preventDefault()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useEffect, useRef, useState, type CSSProperties } from "react"
+import { startTransition, useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import { useLocation, useNavigate } from "react-router-dom"
 import remarkGfm from "remark-gfm"
@@ -64,6 +64,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 type SearchState = {
@@ -90,8 +91,28 @@ type MessageHighlightSpec = {
   terms: string[]
 }
 
+type TopicRailMode = "map" | "inspector"
+
+type ThreadMapMarker = {
+  messageId: string
+  seq: number
+  sender: string
+  top: number
+  height: number
+  focused: boolean
+  localMatched: boolean
+  localActive: boolean
+}
+
+type ThreadMapViewport = {
+  top: number
+  height: number
+}
+
 const SEARCH_HIGHLIGHT_START = "\uE000"
 const SEARCH_HIGHLIGHT_END = "\uE001"
+const THREAD_MAP_DESKTOP_BREAKPOINT = 1280
+const EMPTY_TOPIC_MESSAGES: TopicMessage[] = []
 
 const SIDEBAR_LAYOUT_STYLE = {
   "--sidebar-width": "22rem",
@@ -128,6 +149,10 @@ function mergeMessages(existing: TopicMessage[], incoming: TopicMessage[]): Topi
 
 function statusVariant(status: TopicSummary["status"]): "default" | "secondary" | "outline" {
   return status === "open" ? "default" : "secondary"
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
 }
 
 function snippetLabel(result: SearchResult): string {
@@ -273,7 +298,7 @@ function findTermRanges(text: string, terms: string[]): TextRange[] {
   for (const char of text) {
     const start = originalIndex
     const end = start + char.length
-    for (const _normalizedChar of normalizeSearchText(char)) {
+    for (let normalizedIndex = 0; normalizedIndex < normalizeSearchText(char).length; normalizedIndex += 1) {
       normalizedIndexToOriginalRange.push({ start, end })
     }
     originalIndex = end
@@ -509,6 +534,7 @@ function MessageCard(props: {
   return (
     <article
       id={`msg-${message.message_id}`}
+      data-ab-message-id={message.message_id}
       className={[
         "w-full min-w-0 border px-5 py-5 transition-colors",
         localActive
@@ -550,6 +576,129 @@ function MessageCard(props: {
         </div>
       </div>
     </article>
+  )
+}
+
+function TopicInspectorPanel(props: { topicDetail: TopicDetailResponse }) {
+  const { topicDetail } = props
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 text-sm">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="border border-border bg-background px-3 py-3">
+          <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Status</div>
+          <div className="mt-2 font-medium">{topicDetail.topic.status}</div>
+        </div>
+        <div className="border border-border bg-background px-3 py-3">
+          <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Messages</div>
+          <div className="mt-2 font-medium">{topicDetail.message_count}</div>
+        </div>
+        <div className="border border-border bg-background px-3 py-3">
+          <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Last seq</div>
+          <div className="mt-2 font-medium">{topicDetail.last_seq ?? 0}</div>
+        </div>
+        <div className="border border-border bg-background px-3 py-3">
+          <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Updated</div>
+          <div className="mt-2 font-medium">{formatRelativeTime(topicDetail.topic.last_updated_at)}</div>
+        </div>
+      </div>
+      <div className="border border-border bg-background px-3 py-3">
+        <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Created</div>
+        <div className="mt-2 font-medium">{formatAbsoluteTime(topicDetail.topic.created_at)}</div>
+      </div>
+      <Separator />
+      <div className="flex flex-col gap-3">
+        <div className="font-medium">Presence</div>
+        {topicDetail.presence.length === 0 ? (
+          <p className="text-muted-foreground">No peers have touched this topic recently.</p>
+        ) : (
+          topicDetail.presence.map((presence: CursorPresence) => (
+            <div key={presence.agent_name} className="border border-border bg-background px-3 py-3">
+              <div className="font-medium">{presence.agent_name}</div>
+              <div className="text-xs text-muted-foreground">
+                last seq {presence.last_seq} · {formatRelativeTime(presence.updated_at)}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ThreadMap(props: {
+  topicDetail: TopicDetailResponse
+  markers: ThreadMapMarker[]
+  viewport: ThreadMapViewport | null
+  onJumpToMessage: (messageId: string) => void
+}) {
+  const { topicDetail, markers, viewport, onJumpToMessage } = props
+
+  return (
+    <div className="flex h-full flex-col p-4">
+      <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.18em] text-muted-foreground">
+        <span>Thread map</span>
+        <span>{markers.length}</span>
+      </div>
+      <div className="mb-3 text-sm text-muted-foreground">Click a marker to jump to that message.</div>
+      <div
+        data-ab-thread-map="true"
+        className="relative min-h-72 flex-1 overflow-hidden rounded-md border border-border bg-background/80"
+      >
+        <div className="absolute inset-3 rounded-sm border border-dashed border-border/80" />
+        <div className="absolute inset-y-3 left-1/2 w-px -translate-x-1/2 bg-border/80" />
+        {viewport ? (
+          <div
+            className="pointer-events-none absolute inset-x-2 rounded-md border border-primary/60 bg-primary/12 shadow-[0_0_0_1px_rgba(255,255,255,0.02)]"
+            style={{
+              top: `${clamp(viewport.top * 100, 0, 100)}%`,
+              height: `${clamp(viewport.height * 100, 8, 100)}%`,
+            }}
+          />
+        ) : null}
+        {markers.map((marker) => {
+          const toneClass = marker.localActive
+            ? "bg-sky-400 shadow-[0_0_0_1px_rgba(125,211,252,0.35)]"
+            : marker.localMatched
+              ? "bg-cyan-300/85"
+              : marker.focused
+                ? "bg-primary"
+                : "bg-zinc-500/70"
+          const stateLabel = marker.localActive
+            ? "active find match"
+            : marker.localMatched
+              ? "find match"
+              : marker.focused
+                ? "focused message"
+                : "message"
+
+          return (
+            <button
+              key={marker.messageId}
+              type="button"
+              tabIndex={-1}
+              data-ab-thread-map-marker={marker.messageId}
+              data-focused={marker.focused ? "true" : "false"}
+              data-local-matched={marker.localMatched ? "true" : "false"}
+              data-local-active={marker.localActive ? "true" : "false"}
+              aria-current={marker.localActive ? "true" : undefined}
+              aria-label={`Jump to message #${marker.seq} by ${marker.sender} (${stateLabel})`}
+              className="absolute inset-x-2 rounded-full transition-transform hover:scale-y-110 focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:outline-none"
+              style={{
+                top: `${clamp(marker.top * 100, 0, 100)}%`,
+                height: `${clamp(marker.height * 100, marker.localActive ? 1.4 : 0.75, 12)}%`,
+              }}
+              onClick={() => onJumpToMessage(marker.messageId)}
+            >
+              <span className={`block h-full w-full rounded-full ${toneClass}`} />
+            </button>
+          )
+        })}
+      </div>
+      <div className="mt-3 text-xs text-muted-foreground">
+        {topicDetail.message_count} messages in this topic
+      </div>
+    </div>
   )
 }
 
@@ -597,6 +746,162 @@ function TopicView(props: {
       ? findMatches[Math.min(findState.activeIndex, findMatches.length - 1)]?.message_id ?? null
       : null
   const activeSearchTerms = activeSearchResult ? extractSnippetTerms(activeSearchResult.snippet) : []
+  const localMatchedMessageIds = useMemo(
+    () => new Set(findMatches.map((message) => message.message_id)),
+    [findMatches]
+  )
+  const threadViewportRef = useRef<HTMLDivElement | null>(null)
+  const threadListRef = useRef<HTMLDivElement | null>(null)
+  const [railMode, setRailMode] = useState<TopicRailMode>("map")
+  const [isDesktopThreadMap, setIsDesktopThreadMap] = useState(false)
+  const [threadMapMarkers, setThreadMapMarkers] = useState<ThreadMapMarker[]>([])
+  const [threadMapViewport, setThreadMapViewport] = useState<ThreadMapViewport | null>(null)
+  const [threadMapQualifies, setThreadMapQualifies] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const mediaQuery = window.matchMedia(`(min-width: ${THREAD_MAP_DESKTOP_BREAKPOINT}px)`)
+    const updateDesktopState = () => setIsDesktopThreadMap(mediaQuery.matches)
+
+    updateDesktopState()
+    mediaQuery.addEventListener("change", updateDesktopState)
+    return () => mediaQuery.removeEventListener("change", updateDesktopState)
+  }, [])
+
+  useEffect(() => {
+    if (!isDesktopThreadMap) {
+      return
+    }
+
+    const viewport = threadViewportRef.current
+    const threadList = threadListRef.current
+    if (!viewport || !threadList) {
+      return
+    }
+
+    const messageMap = new Map(
+      topicDetail.messages.map((message) => [
+        message.message_id,
+        {
+          message,
+          focused: topicDetail.focus_message_id === message.message_id,
+          localMatched: localMatchedMessageIds.has(message.message_id),
+          localActive: activeFindMessageId === message.message_id,
+        },
+      ])
+    )
+
+    const updateViewport = () => {
+      const nextQualifies = viewport.scrollHeight > viewport.clientHeight + 1
+      setThreadMapQualifies(nextQualifies)
+
+      if (!nextQualifies || viewport.scrollHeight <= 0) {
+        setThreadMapViewport(null)
+        return
+      }
+
+      const nextViewport = {
+        top: clamp(viewport.scrollTop / viewport.scrollHeight, 0, 1),
+        height: clamp(viewport.clientHeight / viewport.scrollHeight, 0, 1),
+      }
+
+      setThreadMapViewport((current) => {
+        if (
+          current &&
+          Math.abs(current.top - nextViewport.top) < 0.001 &&
+          Math.abs(current.height - nextViewport.height) < 0.001
+        ) {
+          return current
+        }
+        return nextViewport
+      })
+    }
+
+    const measureMarkers = () => {
+      const nextQualifies = viewport.scrollHeight > viewport.clientHeight + 1
+      setThreadMapQualifies(nextQualifies)
+
+      if (!nextQualifies || viewport.scrollHeight <= 0) {
+        setThreadMapMarkers([])
+        setThreadMapViewport(null)
+        return
+      }
+
+      const nextMarkers = Array.from(
+        threadList.querySelectorAll<HTMLElement>("[data-ab-message-id]")
+      ).flatMap((node) => {
+        const messageId = node.dataset.abMessageId
+        if (!messageId) {
+          return []
+        }
+
+        const entry = messageMap.get(messageId)
+        if (!entry) {
+          return []
+        }
+
+        return [
+          {
+            messageId,
+            seq: entry.message.seq,
+            sender: entry.message.sender,
+            top: clamp(node.offsetTop / viewport.scrollHeight, 0, 1),
+            height: clamp(node.offsetHeight / viewport.scrollHeight, 0.0025, 1),
+            focused: entry.focused,
+            localMatched: entry.localMatched,
+            localActive: entry.localActive,
+          } satisfies ThreadMapMarker,
+        ]
+      })
+
+      setThreadMapMarkers(nextMarkers)
+      updateViewport()
+    }
+
+    const onScroll = () => updateViewport()
+    viewport.addEventListener("scroll", onScroll, { passive: true })
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => measureMarkers())
+    if (resizeObserver) {
+      resizeObserver.observe(viewport)
+      resizeObserver.observe(threadList)
+      for (const node of threadList.querySelectorAll<HTMLElement>("[data-ab-message-id]")) {
+        resizeObserver.observe(node)
+      }
+    } else {
+      window.addEventListener("resize", measureMarkers)
+    }
+
+    measureMarkers()
+
+    return () => {
+      viewport.removeEventListener("scroll", onScroll)
+      resizeObserver?.disconnect()
+      if (!resizeObserver) {
+        window.removeEventListener("resize", measureMarkers)
+      }
+    }
+  }, [
+    activeFindMessageId,
+    isDesktopThreadMap,
+    localMatchedMessageIds,
+    topicDetail.focus_message_id,
+    topicDetail.messages,
+  ])
+
+  function jumpToMessage(messageId: string) {
+    const element = document.getElementById(`msg-${messageId}`)
+    if (!element) {
+      return
+    }
+    element.scrollIntoView({ behavior: "smooth", block: "center" })
+  }
+
+  const showSharedRail = isDesktopThreadMap && threadMapQualifies
 
   return (
     <div className="grid h-full min-h-0 flex-1 grid-cols-1 gap-0 border border-border bg-card xl:grid-cols-[minmax(0,1fr)_12rem]">
@@ -706,8 +1011,12 @@ function TopicView(props: {
               <span>Thread</span>
               <span>{topicDetail.message_count} message{topicDetail.message_count === 1 ? "" : "s"}</span>
             </div>
-            <ScrollArea className="min-h-0 flex-1 bg-[#1a1d22]">
-              <div className="flex min-h-full w-full min-w-0 flex-col gap-3 p-4">
+            <ScrollArea
+              className="min-h-0 flex-1 bg-[#1a1d22]"
+              data-ab-topic-thread-scroll-area="true"
+              viewportRef={threadViewportRef}
+            >
+              <div ref={threadListRef} className="flex min-h-full w-full min-w-0 flex-col gap-3 p-4">
                 {topicDetail.messages.length === 0 ? (
                   <div className="flex min-h-64 flex-col items-center justify-center gap-3 border border-dashed border-border bg-muted/20 text-center">
                     <MessageSquareMoreIcon className="size-8 text-muted-foreground" />
@@ -764,50 +1073,43 @@ function TopicView(props: {
         </CardContent>
       </section>
       <aside className="hidden min-h-0 flex-col overflow-hidden border-l border-border bg-[#202227] xl:flex">
-        <CardHeader className="border-b border-border px-4 py-3">
-          <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Inspector</div>
-          <CardTitle className="text-base">Topic metadata</CardTitle>
-        </CardHeader>
-        <CardContent className="flex flex-1 flex-col gap-4 p-4 text-sm">
-          <div className="grid grid-cols-2 gap-2">
-            <div className="border border-border bg-background px-3 py-3">
-              <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Status</div>
-              <div className="mt-2 font-medium">{topicDetail.topic.status}</div>
-            </div>
-            <div className="border border-border bg-background px-3 py-3">
-              <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Messages</div>
-              <div className="mt-2 font-medium">{topicDetail.message_count}</div>
-            </div>
-            <div className="border border-border bg-background px-3 py-3">
-              <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Last seq</div>
-              <div className="mt-2 font-medium">{topicDetail.last_seq ?? 0}</div>
-            </div>
-            <div className="border border-border bg-background px-3 py-3">
-              <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Updated</div>
-              <div className="mt-2 font-medium">{formatRelativeTime(topicDetail.topic.last_updated_at)}</div>
-            </div>
-          </div>
-          <div className="border border-border bg-background px-3 py-3">
-            <div className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">Created</div>
-            <div className="mt-2 font-medium">{formatAbsoluteTime(topicDetail.topic.created_at)}</div>
-          </div>
-          <Separator />
-          <div className="flex flex-col gap-3">
-            <div className="font-medium">Presence</div>
-            {topicDetail.presence.length === 0 ? (
-              <p className="text-muted-foreground">No peers have touched this topic recently.</p>
-            ) : (
-              topicDetail.presence.map((presence: CursorPresence) => (
-                <div key={presence.agent_name} className="border border-border bg-background px-3 py-3">
-                  <div className="font-medium">{presence.agent_name}</div>
-                  <div className="text-xs text-muted-foreground">
-                    last seq {presence.last_seq} · {formatRelativeTime(presence.updated_at)}
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
-        </CardContent>
+        {showSharedRail ? (
+          <Tabs
+            value={railMode}
+            onValueChange={(value) => setRailMode(value as TopicRailMode)}
+            className="flex min-h-0 flex-1 flex-col gap-0"
+          >
+            <CardHeader className="gap-3 border-b border-border px-4 py-3">
+              <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Topic rail</div>
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="map">Map</TabsTrigger>
+                <TabsTrigger value="inspector">Inspector</TabsTrigger>
+              </TabsList>
+            </CardHeader>
+            <TabsContent value="map" className="mt-0 flex min-h-0 flex-1 flex-col">
+              <ThreadMap
+                topicDetail={topicDetail}
+                markers={threadMapMarkers}
+                viewport={threadMapViewport}
+                onJumpToMessage={jumpToMessage}
+              />
+            </TabsContent>
+            <TabsContent value="inspector" className="mt-0 flex min-h-0 flex-1 flex-col">
+              <CardHeader className="border-b border-border px-4 py-3">
+                <CardTitle className="text-base">Topic metadata</CardTitle>
+              </CardHeader>
+              <TopicInspectorPanel topicDetail={topicDetail} />
+            </TabsContent>
+          </Tabs>
+        ) : (
+          <>
+            <CardHeader className="border-b border-border px-4 py-3">
+              <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Inspector</div>
+              <CardTitle className="text-base">Topic metadata</CardTitle>
+            </CardHeader>
+            <TopicInspectorPanel topicDetail={topicDetail} />
+          </>
+        )}
       </aside>
     </div>
   )
@@ -1494,10 +1796,17 @@ export default function App() {
     }
   }, [routeTopicId])
 
-  const topicFindMatches =
-    topicDetail && topicFindState.query.trim()
-      ? topicDetail.messages.filter((message) => messageContainsText(message, topicFindState.query.trim()))
-      : []
+  const topicMessages = topicDetail?.messages ?? EMPTY_TOPIC_MESSAGES
+
+  const topicFindMatches = useMemo(() => {
+    if (!topicFindState.query.trim()) {
+      return []
+    }
+
+    return topicMessages.filter((message) =>
+      messageContainsText(message, topicFindState.query.trim())
+    )
+  }, [topicMessages, topicFindState.query])
   const activeRailSearchResult =
     routeTopicId && focusMessageId
       ? railSearchState.results.find(
@@ -1788,6 +2097,7 @@ export default function App() {
                   </Card>
                 ) : topicDetail ? (
         <TopicView
+          key={topicDetail.topic.topic_id}
           topicDetail={topicDetail}
           activeSearchResult={activeRailSearchResult}
           sidebarSearchQuery={railSearchState.query}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,10 +109,22 @@ type ThreadMapViewport = {
   height: number
 }
 
+type ThreadMapSenderTone = {
+  key: string
+  borderColor: string
+  backgroundColor: string
+  lineColor: string
+}
+
 const SEARCH_HIGHLIGHT_START = "\uE000"
 const SEARCH_HIGHLIGHT_END = "\uE001"
 const THREAD_MAP_DESKTOP_BREAKPOINT = 1280
 const EMPTY_TOPIC_MESSAGES: TopicMessage[] = []
+const THREAD_MAP_LINE_PATTERNS = [
+  [92, 76, 84],
+  [84, 93, 68],
+  [89, 72, 80],
+] as const
 
 const SIDEBAR_LAYOUT_STYLE = {
   "--sidebar-width": "22rem",
@@ -153,6 +165,24 @@ function statusVariant(status: TopicSummary["status"]): "default" | "secondary" 
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
+}
+
+function hashString(value: string): number {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0
+  }
+  return hash
+}
+
+function getThreadMapSenderTone(sender: string): ThreadMapSenderTone {
+  const hue = hashString(sender) % 360
+  return {
+    key: String(hue),
+    borderColor: `hsla(${hue}, 72%, 74%, 0.36)`,
+    backgroundColor: `hsla(${hue}, 68%, 58%, 0.14)`,
+    lineColor: `hsla(${hue}, 92%, 92%, 0.84)`,
+  }
 }
 
 function snippetLabel(result: SearchResult): string {
@@ -645,11 +675,11 @@ function ThreadMap(props: {
         data-ab-thread-map="true"
         className="relative min-h-72 flex-1 overflow-hidden rounded-md border border-border bg-background/80"
       >
-        <div className="absolute inset-y-3 left-1/2 w-16 -translate-x-1/2 rounded-full border border-border/70 bg-muted/30 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]" />
+        <div className="absolute inset-y-3 left-1/2 w-[4.5rem] -translate-x-1/2 rounded-[20px] border border-border/70 bg-muted/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]" />
         <div className="absolute inset-y-4 left-1/2 w-px -translate-x-1/2 bg-border/80" />
         {viewport ? (
           <div
-            className="pointer-events-none absolute left-1/2 w-20 -translate-x-1/2 rounded-xl border border-primary/45 bg-primary/10 shadow-[0_0_0_1px_rgba(255,255,255,0.02)]"
+            className="pointer-events-none absolute left-1/2 w-[5.5rem] -translate-x-1/2 rounded-2xl border border-primary/45 bg-primary/10 shadow-[0_0_0_1px_rgba(255,255,255,0.02)]"
             style={{
               top: `${clamp(viewport.top * 100, 0, 100)}%`,
               height: `${clamp(viewport.height * 100, 8, 100)}%`,
@@ -658,16 +688,36 @@ function ThreadMap(props: {
         ) : null}
         {markers.map((marker) => {
           const center = clamp((marker.top + marker.height / 2) * 100, 0, 100)
-          const visibleWidth = marker.localActive ? 20 : marker.focused ? 16 : marker.localMatched ? 14 : 10
-          const visibleHeight = marker.localActive ? 12 : marker.focused ? 10 : marker.localMatched ? 9 : 8
-          const hitAreaHeight = Math.max(visibleHeight + 6, 14)
-          const toneClass = marker.localActive
-            ? "border-sky-300/90 bg-sky-300 shadow-[0_0_0_4px_rgba(56,189,248,0.14)]"
+          const visibleWidth = marker.localActive ? 28 : marker.focused ? 26 : marker.localMatched ? 24 : 22
+          const visibleHeight = marker.localActive ? 16 : marker.focused ? 15 : marker.localMatched ? 14 : 13
+          const hitAreaHeight = Math.max(visibleHeight + 6, 20)
+          const senderTone = getThreadMapSenderTone(marker.sender)
+          const tone = marker.localActive
+            ? {
+                borderColor: "rgba(125, 211, 252, 0.95)",
+                backgroundColor: "rgba(56, 189, 248, 0.24)",
+                lineColor: "rgba(224, 242, 254, 0.98)",
+                boxShadow: "0 0 0 4px rgba(56, 189, 248, 0.12)",
+              }
             : marker.localMatched
-              ? "border-cyan-300/80 bg-cyan-300/90"
+              ? {
+                  borderColor: "rgba(103, 232, 249, 0.82)",
+                  backgroundColor: "rgba(34, 211, 238, 0.18)",
+                  lineColor: "rgba(236, 254, 255, 0.96)",
+                  boxShadow: "none",
+                }
               : marker.focused
-                ? "border-primary/80 bg-primary"
-                : "border-border/70 bg-zinc-400/85"
+                ? {
+                    borderColor: "rgba(113, 113, 122, 0.82)",
+                    backgroundColor: "rgba(244, 244, 245, 0.18)",
+                    lineColor: "rgba(250, 250, 250, 0.98)",
+                    boxShadow: "none",
+                  }
+                : {
+                    ...senderTone,
+                    boxShadow: "none",
+                  }
+          const linePattern = THREAD_MAP_LINE_PATTERNS[marker.seq % THREAD_MAP_LINE_PATTERNS.length]!
           const stateLabel = marker.localActive
             ? "active find match"
             : marker.localMatched
@@ -685,24 +735,41 @@ function ThreadMap(props: {
               data-focused={marker.focused ? "true" : "false"}
               data-local-matched={marker.localMatched ? "true" : "false"}
               data-local-active={marker.localActive ? "true" : "false"}
+              data-sender-tone={senderTone.key}
               aria-current={marker.localActive ? "true" : undefined}
               aria-label={`Jump to message #${marker.seq} by ${marker.sender} (${stateLabel})`}
               className="absolute left-1/2 -translate-x-1/2 rounded-full transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:outline-none"
               style={{
                 top: `calc(${center}% - ${hitAreaHeight / 2}px)`,
                 height: `${hitAreaHeight}px`,
-                width: "36px",
+                width: "42px",
               }}
               onClick={() => onJumpToMessage(marker.messageId)}
             >
               <span
-                className={`mx-auto block rounded-full border ${toneClass}`}
+                className="mx-auto flex items-start justify-center rounded-md border px-1.5 py-1"
                 style={{
                   width: `${visibleWidth}px`,
                   height: `${visibleHeight}px`,
                   marginTop: `${(hitAreaHeight - visibleHeight) / 2}px`,
+                  borderColor: tone.borderColor,
+                  backgroundColor: tone.backgroundColor,
+                  boxShadow: tone.boxShadow,
                 }}
-              />
+              >
+                <span className="flex w-full flex-col items-start gap-[2px]">
+                  {linePattern.map((width, index) => (
+                    <span
+                      key={index}
+                      className="block h-[1.5px] rounded-full"
+                      style={{
+                        width: `${width}%`,
+                        backgroundColor: tone.lineColor,
+                      }}
+                    />
+                  ))}
+                </span>
+              </span>
             </button>
           )
         })}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -697,6 +697,13 @@ function ThreadMap(props: {
     onViewportDrag(clamp(pointerTop - dragState.grabOffset, 0, maxTop))
   }
 
+  const renderedViewport = viewport
+    ? {
+        height: clamp(viewport.height, 0.08, 1),
+        top: clamp(viewport.top, 0, 1 - clamp(viewport.height, 0.08, 1)),
+      }
+    : null
+
   return (
     <div
       data-ab-thread-map="true"
@@ -708,13 +715,13 @@ function ThreadMap(props: {
     >
       <div ref={mapRef} data-ab-thread-map-frame="true" className="relative h-full w-full">
         <div className="absolute inset-1 bg-muted/8" />
-        {viewport ? (
+        {renderedViewport ? (
           <div
             data-ab-thread-map-viewport="true"
             className="absolute inset-x-1 z-10 cursor-grab border-y border-primary/35 bg-primary/10 active:cursor-grabbing"
             style={{
-              top: `${clamp(viewport.top * 100, 0, 100)}%`,
-              height: `${clamp(viewport.height * 100, 8, 100)}%`,
+              top: `${renderedViewport.top * 100}%`,
+              height: `${renderedViewport.height * 100}%`,
             }}
             onClick={(event) => event.stopPropagation()}
             onPointerDown={(event) => {
@@ -732,9 +739,13 @@ function ThreadMap(props: {
                 return
               }
 
-              const viewportHeight = clamp(viewport.height, 0, 1)
+              const viewportHeight = renderedViewport.height
               dragStateRef.current = {
-                grabOffset: clamp((event.clientY - rect.top) / rect.height - viewport.top, 0, viewportHeight),
+                grabOffset: clamp(
+                  (event.clientY - rect.top) / rect.height - renderedViewport.top,
+                  0,
+                  viewportHeight
+                ),
                 viewportHeight,
               }
               event.currentTarget.setPointerCapture(event.pointerId)
@@ -783,8 +794,9 @@ function ThreadMap(props: {
             : 100
           const slotTop = index === 0 ? 0 : (previousCenter + center) / 2
           const slotBottom = index === markers.length - 1 ? 100 : (center + nextCenter) / 2
-          const slotHeight = Math.max(slotBottom - slotTop, 0.25)
-          const glyphTop = clamp(((center - slotTop) / slotHeight) * 100, 0, 100)
+          const slotHeight = Math.max(slotBottom - slotTop, 0)
+          const glyphSlotHeight = Math.max(slotHeight, 0.25)
+          const glyphTop = clamp(((center - slotTop) / glyphSlotHeight) * 100, 0, 100)
           const visibleHeight = marker.localActive ? 11 : marker.focused ? 10 : marker.localMatched ? 9 : 8
           const senderTone = senderTones.get(marker.sender) ?? getThreadMapSenderTone(marker.sender)
           const tone = marker.localActive
@@ -1158,7 +1170,22 @@ function TopicView(props: {
 
     revealThreadMap()
     viewport.scrollTop = clamp(top, 0, 1) * viewport.scrollHeight
-    viewport.dispatchEvent(new Event("scroll"))
+    if (viewport.scrollHeight > 0) {
+      const nextViewport = {
+        top: clamp(viewport.scrollTop / viewport.scrollHeight, 0, 1),
+        height: clamp(viewport.clientHeight / viewport.scrollHeight, 0, 1),
+      }
+      setThreadMapViewport((current) => {
+        if (
+          current &&
+          Math.abs(current.top - nextViewport.top) < 0.001 &&
+          Math.abs(current.height - nextViewport.height) < 0.001
+        ) {
+          return current
+        }
+        return nextViewport
+      })
+    }
   }
 
   const showThreadMapOverlay = isDesktopThreadMap && threadMapQualifies

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -328,7 +328,8 @@ function findTermRanges(text: string, terms: string[]): TextRange[] {
   for (const char of text) {
     const start = originalIndex
     const end = start + char.length
-    for (let normalizedIndex = 0; normalizedIndex < normalizeSearchText(char).length; normalizedIndex += 1) {
+    const normalizedChar = normalizeSearchText(char)
+    for (let normalizedIndex = 0; normalizedIndex < normalizedChar.length; normalizedIndex += 1) {
       normalizedIndexToOriginalRange.push({ start, end })
     }
     originalIndex = end

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -918,8 +918,10 @@ function TopicView(props: {
     onDeleteTopic,
   } = props
 
+  const trimmedFindQuery = findState.query.trim()
+  const hasTrimmedFindQuery = Boolean(trimmedFindQuery)
   const activeFindMessageId =
-    findState.query.trim() && findMatches.length > 0
+    hasTrimmedFindQuery && findMatches.length > 0
       ? findMatches[Math.min(findState.activeIndex, findMatches.length - 1)]?.message_id ?? null
       : null
   const activeSearchTerms = activeSearchResult ? extractSnippetTerms(activeSearchResult.snippet) : []
@@ -1319,9 +1321,8 @@ function TopicView(props: {
                   ) : (
                     topicDetail.messages.map((message) => {
                       const localMatched =
-                        Boolean(findState.query.trim()) &&
-                        findMatches.some((candidate) => candidate.message_id === message.message_id)
-                      const localFindQuery = localMatched ? findState.query.trim() : null
+                        hasTrimmedFindQuery && localMatchedMessageIds.has(message.message_id)
+                      const localFindQuery = localMatched ? trimmedFindQuery : null
                       const focusedSearchMessage =
                         activeSearchResult?.message_id === message.message_id ? activeSearchResult : null
                       const highlightTerms = uniqueStrings([

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
+import { startTransition, useEffect, useEffectEvent, useMemo, useRef, useState, type CSSProperties } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import { useLocation, useNavigate } from "react-router-dom"
 import remarkGfm from "remark-gfm"
@@ -64,7 +64,6 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 type SearchState = {
@@ -90,8 +89,6 @@ type TextRange = {
 type MessageHighlightSpec = {
   terms: string[]
 }
-
-type TopicRailMode = "map" | "inspector"
 
 type ThreadMapMarker = {
   messageId: string
@@ -119,6 +116,7 @@ type ThreadMapSenderTone = {
 const SEARCH_HIGHLIGHT_START = "\uE000"
 const SEARCH_HIGHLIGHT_END = "\uE001"
 const THREAD_MAP_DESKTOP_BREAKPOINT = 1280
+const THREAD_MAP_AUTO_HIDE_MS = 1800
 const EMPTY_TOPIC_MESSAGES: TopicMessage[] = []
 const THREAD_MAP_LINE_PATTERNS = [
   [92, 76, 84],
@@ -176,12 +174,14 @@ function hashString(value: string): number {
 }
 
 function getThreadMapSenderTone(sender: string): ThreadMapSenderTone {
-  const hue = hashString(sender) % 360
+  const seed = hashString(sender)
+  const hue = 198 + (seed % 48)
+  const saturation = 18 + (Math.floor(seed / 48) % 4) * 10
   return {
-    key: String(hue),
-    borderColor: `hsla(${hue}, 72%, 74%, 0.36)`,
-    backgroundColor: `hsla(${hue}, 68%, 58%, 0.14)`,
-    lineColor: `hsla(${hue}, 92%, 92%, 0.84)`,
+    key: `${hue}-${saturation}`,
+    borderColor: `hsla(${hue}, ${Math.min(saturation + 8, 58)}%, 76%, 0.36)`,
+    backgroundColor: `hsla(${hue}, ${saturation}%, 62%, 0.14)`,
+    lineColor: `hsla(${hue}, ${Math.min(saturation + 14, 64)}%, 92%, 0.62)`,
   }
 }
 
@@ -657,65 +657,141 @@ function TopicInspectorPanel(props: { topicDetail: TopicDetailResponse }) {
 }
 
 function ThreadMap(props: {
-  topicDetail: TopicDetailResponse
   markers: ThreadMapMarker[]
   viewport: ThreadMapViewport | null
+  visible: boolean
   onJumpToMessage: (messageId: string) => void
+  onViewportDrag: (top: number) => void
 }) {
-  const { topicDetail, markers, viewport, onJumpToMessage } = props
+  const { markers, viewport, visible, onJumpToMessage, onViewportDrag } = props
+  const mapRef = useRef<HTMLDivElement | null>(null)
+  const dragStateRef = useRef<{ grabOffset: number; viewportHeight: number } | null>(null)
+
+  const moveViewportCursor = (clientY: number) => {
+    const map = mapRef.current
+    const dragState = dragStateRef.current
+    if (!map || !dragState) {
+      return
+    }
+
+    const rect = map.getBoundingClientRect()
+    if (rect.height <= 0) {
+      return
+    }
+
+    const pointerTop = (clientY - rect.top) / rect.height
+    const maxTop = Math.max(1 - dragState.viewportHeight, 0)
+    onViewportDrag(clamp(pointerTop - dragState.grabOffset, 0, maxTop))
+  }
 
   return (
-    <div className="flex h-full flex-col p-4">
-      <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.18em] text-muted-foreground">
-        <span>Thread map</span>
-        <span>{markers.length}</span>
-      </div>
-      <div className="mb-3 text-sm text-muted-foreground">Click a marker to jump to that message.</div>
-      <div
-        data-ab-thread-map="true"
-        className="relative min-h-72 flex-1 overflow-hidden rounded-md border border-border bg-background/80"
-      >
-        <div className="absolute inset-y-3 left-1/2 w-[4.5rem] -translate-x-1/2 rounded-[20px] border border-border/70 bg-muted/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]" />
-        <div className="absolute inset-y-4 left-1/2 w-px -translate-x-1/2 bg-border/80" />
+    <div
+      data-ab-thread-map="true"
+      data-visible={visible ? "true" : "false"}
+      aria-hidden={visible ? undefined : true}
+      className={`absolute inset-y-3 right-3 z-20 w-[7rem] overflow-hidden border border-border/60 bg-[#17191e]/84 shadow-[0_8px_20px_rgba(0,0,0,0.24)] backdrop-blur-[2px] transition-all duration-200 ${
+        visible ? "opacity-100" : "pointer-events-none translate-x-2 opacity-0"
+      }`}
+    >
+      <div ref={mapRef} data-ab-thread-map-frame="true" className="relative h-full w-full">
+        <div className="absolute inset-1 bg-muted/8" />
         {viewport ? (
           <div
-            className="pointer-events-none absolute left-1/2 w-[5.5rem] -translate-x-1/2 rounded-2xl border border-primary/45 bg-primary/10 shadow-[0_0_0_1px_rgba(255,255,255,0.02)]"
+            data-ab-thread-map-viewport="true"
+            className="absolute inset-x-1 z-10 cursor-grab border-y border-primary/35 bg-primary/10 active:cursor-grabbing"
             style={{
               top: `${clamp(viewport.top * 100, 0, 100)}%`,
               height: `${clamp(viewport.height * 100, 8, 100)}%`,
             }}
+            onClick={(event) => event.stopPropagation()}
+            onPointerDown={(event) => {
+              if (event.button !== 0) {
+                return
+              }
+
+              const map = mapRef.current
+              if (!map) {
+                return
+              }
+
+              const rect = map.getBoundingClientRect()
+              if (rect.height <= 0) {
+                return
+              }
+
+              const viewportHeight = clamp(viewport.height, 0, 1)
+              dragStateRef.current = {
+                grabOffset: clamp((event.clientY - rect.top) / rect.height - viewport.top, 0, viewportHeight),
+                viewportHeight,
+              }
+              event.currentTarget.setPointerCapture(event.pointerId)
+              event.preventDefault()
+              event.stopPropagation()
+              moveViewportCursor(event.clientY)
+            }}
+            onPointerMove={(event) => {
+              if (!dragStateRef.current) {
+                return
+              }
+
+              event.preventDefault()
+              event.stopPropagation()
+              moveViewportCursor(event.clientY)
+            }}
+            onPointerUp={(event) => {
+              if (!dragStateRef.current) {
+                return
+              }
+
+              dragStateRef.current = null
+              event.currentTarget.releasePointerCapture(event.pointerId)
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onPointerCancel={(event) => {
+              dragStateRef.current = null
+              event.currentTarget.releasePointerCapture(event.pointerId)
+            }}
           />
         ) : null}
-        {markers.map((marker) => {
+        {markers.map((marker, index) => {
           const center = clamp((marker.top + marker.height / 2) * 100, 0, 100)
-          const visibleWidth = marker.localActive ? 28 : marker.focused ? 26 : marker.localMatched ? 24 : 22
-          const visibleHeight = marker.localActive ? 16 : marker.focused ? 15 : marker.localMatched ? 14 : 13
-          const hitAreaHeight = Math.max(visibleHeight + 6, 20)
+          const previousMarker = markers[index - 1]
+          const nextMarker = markers[index + 1]
+          const previousCenter = previousMarker
+            ? clamp((previousMarker.top + previousMarker.height / 2) * 100, 0, 100)
+            : 0
+          const nextCenter = nextMarker
+            ? clamp((nextMarker.top + nextMarker.height / 2) * 100, 0, 100)
+            : 100
+          const slotTop = index === 0 ? 0 : (previousCenter + center) / 2
+          const slotBottom = index === markers.length - 1 ? 100 : (center + nextCenter) / 2
+          const slotHeight = Math.max(slotBottom - slotTop, 0.25)
+          const glyphTop = clamp(((center - slotTop) / slotHeight) * 100, 0, 100)
+          const visibleHeight = marker.localActive ? 11 : marker.focused ? 10 : marker.localMatched ? 9 : 8
           const senderTone = getThreadMapSenderTone(marker.sender)
           const tone = marker.localActive
             ? {
-                borderColor: "rgba(125, 211, 252, 0.95)",
-                backgroundColor: "rgba(56, 189, 248, 0.24)",
-                lineColor: "rgba(224, 242, 254, 0.98)",
-                boxShadow: "0 0 0 4px rgba(56, 189, 248, 0.12)",
+                accentColor: "rgba(125, 211, 252, 0.95)",
+                backgroundColor: "rgba(56, 189, 248, 0.12)",
+                lineColor: "rgba(224, 242, 254, 0.84)",
               }
             : marker.localMatched
               ? {
-                  borderColor: "rgba(103, 232, 249, 0.82)",
-                  backgroundColor: "rgba(34, 211, 238, 0.18)",
-                  lineColor: "rgba(236, 254, 255, 0.96)",
-                  boxShadow: "none",
+                  accentColor: "rgba(103, 232, 249, 0.82)",
+                  backgroundColor: "rgba(34, 211, 238, 0.09)",
+                  lineColor: "rgba(236, 254, 255, 0.76)",
                 }
               : marker.focused
                 ? {
-                    borderColor: "rgba(113, 113, 122, 0.82)",
-                    backgroundColor: "rgba(244, 244, 245, 0.18)",
-                    lineColor: "rgba(250, 250, 250, 0.98)",
-                    boxShadow: "none",
+                    accentColor: "rgba(113, 113, 122, 0.82)",
+                    backgroundColor: "rgba(244, 244, 245, 0.08)",
+                    lineColor: "rgba(250, 250, 250, 0.74)",
                   }
                 : {
-                    ...senderTone,
-                    boxShadow: "none",
+                    accentColor: senderTone.borderColor,
+                    backgroundColor: "transparent",
+                    lineColor: senderTone.lineColor,
                   }
           const linePattern = THREAD_MAP_LINE_PATTERNS[marker.seq % THREAD_MAP_LINE_PATTERNS.length]!
           const stateLabel = marker.localActive
@@ -738,30 +814,38 @@ function ThreadMap(props: {
               data-sender-tone={senderTone.key}
               aria-current={marker.localActive ? "true" : undefined}
               aria-label={`Jump to message #${marker.seq} by ${marker.sender} (${stateLabel})`}
-              className="absolute left-1/2 -translate-x-1/2 rounded-full transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:outline-none"
+              className="absolute left-0 right-0 transition-colors focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:outline-none"
               style={{
-                top: `calc(${center}% - ${hitAreaHeight / 2}px)`,
-                height: `${hitAreaHeight}px`,
-                width: "42px",
+                top: `${slotTop}%`,
+                height: `${slotHeight}%`,
               }}
               onClick={() => onJumpToMessage(marker.messageId)}
             >
               <span
-                className="mx-auto flex items-start justify-center rounded-md border px-1.5 py-1"
+                className="absolute left-2 right-2 block px-2"
                 style={{
-                  width: `${visibleWidth}px`,
+                  top: `${glyphTop}%`,
                   height: `${visibleHeight}px`,
-                  marginTop: `${(hitAreaHeight - visibleHeight) / 2}px`,
-                  borderColor: tone.borderColor,
+                  transform: "translateY(-50%)",
                   backgroundColor: tone.backgroundColor,
-                  boxShadow: tone.boxShadow,
                 }}
               >
-                <span className="flex w-full flex-col items-start gap-[2px]">
+                {(marker.localActive || marker.localMatched || marker.focused) ? (
+                  <span
+                    className="absolute inset-y-0 left-0 w-[2px]"
+                    style={{ backgroundColor: tone.accentColor }}
+                  />
+                ) : null}
+                <span
+                  className="flex h-full w-full flex-col justify-center gap-[2px]"
+                  style={{
+                    paddingLeft: marker.localActive || marker.localMatched || marker.focused ? "6px" : "0px",
+                  }}
+                >
                   {linePattern.map((width, index) => (
                     <span
                       key={index}
-                      className="block h-[1.5px] rounded-full"
+                      className="block h-px"
                       style={{
                         width: `${width}%`,
                         backgroundColor: tone.lineColor,
@@ -773,9 +857,6 @@ function ThreadMap(props: {
             </button>
           )
         })}
-      </div>
-      <div className="mt-3 text-xs text-muted-foreground">
-        {topicDetail.message_count} messages in this topic
       </div>
     </div>
   )
@@ -831,11 +912,12 @@ function TopicView(props: {
   )
   const threadViewportRef = useRef<HTMLDivElement | null>(null)
   const threadListRef = useRef<HTMLDivElement | null>(null)
-  const [railMode, setRailMode] = useState<TopicRailMode>("map")
+  const threadMapHideTimerRef = useRef<number | null>(null)
   const [isDesktopThreadMap, setIsDesktopThreadMap] = useState(false)
   const [threadMapMarkers, setThreadMapMarkers] = useState<ThreadMapMarker[]>([])
   const [threadMapViewport, setThreadMapViewport] = useState<ThreadMapViewport | null>(null)
   const [threadMapQualifies, setThreadMapQualifies] = useState(false)
+  const [threadMapVisible, setThreadMapVisible] = useState(false)
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -849,6 +931,57 @@ function TopicView(props: {
     mediaQuery.addEventListener("change", updateDesktopState)
     return () => mediaQuery.removeEventListener("change", updateDesktopState)
   }, [])
+
+  const clearThreadMapHideTimer = useEffectEvent(() => {
+    if (threadMapHideTimerRef.current !== null) {
+      window.clearTimeout(threadMapHideTimerRef.current)
+      threadMapHideTimerRef.current = null
+    }
+  })
+
+  const scheduleThreadMapHide = useEffectEvent((delay = THREAD_MAP_AUTO_HIDE_MS) => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    clearThreadMapHideTimer()
+    threadMapHideTimerRef.current = window.setTimeout(() => {
+      setThreadMapVisible(false)
+      threadMapHideTimerRef.current = null
+    }, delay)
+  })
+
+  const revealThreadMap = useEffectEvent((delay = THREAD_MAP_AUTO_HIDE_MS) => {
+    if (typeof window === "undefined" || !isDesktopThreadMap || !threadMapQualifies) {
+      return
+    }
+
+    setThreadMapVisible(true)
+    scheduleThreadMapHide(delay)
+  })
+
+  useEffect(() => {
+    if (!isDesktopThreadMap || !threadMapQualifies) {
+      setThreadMapVisible(false)
+      if (threadMapHideTimerRef.current !== null) {
+        window.clearTimeout(threadMapHideTimerRef.current)
+        threadMapHideTimerRef.current = null
+      }
+    }
+
+    return () => {
+      if (threadMapHideTimerRef.current !== null) {
+        window.clearTimeout(threadMapHideTimerRef.current)
+        threadMapHideTimerRef.current = null
+      }
+    }
+  }, [isDesktopThreadMap, threadMapQualifies])
+
+  useEffect(() => {
+    if (findState.open || activeFindMessageId || topicDetail.focus_message_id) {
+      revealThreadMap()
+    }
+  }, [activeFindMessageId, findState.open, isDesktopThreadMap, revealThreadMap, threadMapQualifies, topicDetail.focus_message_id])
 
   useEffect(() => {
     if (!isDesktopThreadMap) {
@@ -940,7 +1073,10 @@ function TopicView(props: {
       updateViewport()
     }
 
-    const onScroll = () => updateViewport()
+    const onScroll = () => {
+      updateViewport()
+      revealThreadMap()
+    }
     viewport.addEventListener("scroll", onScroll, { passive: true })
 
     const resizeObserver =
@@ -973,6 +1109,7 @@ function TopicView(props: {
   ])
 
   function jumpToMessage(messageId: string) {
+    revealThreadMap()
     const element = document.getElementById(`msg-${messageId}`)
     if (!element) {
       return
@@ -980,7 +1117,18 @@ function TopicView(props: {
     element.scrollIntoView({ behavior: "smooth", block: "center" })
   }
 
-  const showSharedRail = isDesktopThreadMap && threadMapQualifies
+  function dragThreadMapViewport(top: number) {
+    const viewport = threadViewportRef.current
+    if (!viewport) {
+      return
+    }
+
+    revealThreadMap()
+    viewport.scrollTop = clamp(top, 0, 1) * viewport.scrollHeight
+    viewport.dispatchEvent(new Event("scroll"))
+  }
+
+  const showThreadMapOverlay = isDesktopThreadMap && threadMapQualifies
 
   return (
     <div className="grid h-full min-h-0 flex-1 grid-cols-1 gap-0 border border-border bg-card xl:grid-cols-[minmax(0,1fr)_12rem]">
@@ -1090,105 +1238,107 @@ function TopicView(props: {
               <span>Thread</span>
               <span>{topicDetail.message_count} message{topicDetail.message_count === 1 ? "" : "s"}</span>
             </div>
-            <ScrollArea
-              className="min-h-0 flex-1 bg-[#1a1d22]"
-              data-ab-topic-thread-scroll-area="true"
-              viewportRef={threadViewportRef}
+            <div
+              data-ab-thread-map-region="true"
+              className="relative flex min-h-0 flex-1 flex-col"
+              onPointerMove={() => {
+                if (threadMapVisible) {
+                  revealThreadMap()
+                }
+              }}
+              onPointerLeave={() => {
+                if (threadMapVisible) {
+                  scheduleThreadMapHide(500)
+                }
+              }}
             >
-              <div ref={threadListRef} className="flex min-h-full w-full min-w-0 flex-col gap-3 p-4">
-                {topicDetail.messages.length === 0 ? (
-                  <div className="flex min-h-64 flex-col items-center justify-center gap-3 border border-dashed border-border bg-muted/20 text-center">
-                    <MessageSquareMoreIcon className="size-8 text-muted-foreground" />
-                    <div className="flex flex-col gap-1">
-                      <div className="font-medium">No messages yet</div>
-                      <div className="text-sm text-muted-foreground">
-                        This topic exists, but it does not have any content yet.
+              {showThreadMapOverlay ? (
+                <>
+                  <div
+                    data-ab-thread-map-hotspot="true"
+                    className="absolute inset-y-0 right-0 z-10 w-10"
+                    onPointerEnter={() => revealThreadMap()}
+                    onPointerMove={() => revealThreadMap()}
+                  />
+                  <ThreadMap
+                    visible={threadMapVisible}
+                    markers={threadMapMarkers}
+                    viewport={threadMapViewport}
+                    onJumpToMessage={jumpToMessage}
+                    onViewportDrag={dragThreadMapViewport}
+                  />
+                </>
+              ) : null}
+              <ScrollArea
+                className="min-h-0 flex-1 bg-[#1a1d22]"
+                data-ab-topic-thread-scroll-area="true"
+                viewportRef={threadViewportRef}
+              >
+                <div ref={threadListRef} className="flex min-h-full w-full min-w-0 flex-col gap-3 p-4">
+                  {topicDetail.messages.length === 0 ? (
+                    <div className="flex min-h-64 flex-col items-center justify-center gap-3 border border-dashed border-border bg-muted/20 text-center">
+                      <MessageSquareMoreIcon className="size-8 text-muted-foreground" />
+                      <div className="flex flex-col gap-1">
+                        <div className="font-medium">No messages yet</div>
+                        <div className="text-sm text-muted-foreground">
+                          This topic exists, but it does not have any content yet.
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ) : (
-                  topicDetail.messages.map((message) => {
-                    const localMatched =
-                      Boolean(findState.query.trim()) &&
-                      findMatches.some((candidate) => candidate.message_id === message.message_id)
-                    const localFindQuery = localMatched ? findState.query.trim() : null
-                    const focusedSearchMessage =
-                      activeSearchResult?.message_id === message.message_id ? activeSearchResult : null
-                    const highlightTerms = uniqueStrings([
-                      ...(localFindQuery ? [localFindQuery] : []),
-                      ...(focusedSearchMessage
-                        ? activeSearchTerms.length > 0
-                          ? activeSearchTerms
-                          : sidebarSearchQuery.trim()
-                            ? tokenizeSearchQuery(sidebarSearchQuery)
-                            : []
-                        : []),
-                    ])
-                    const highlight =
-                      highlightTerms.length > 0
-                        ? {
-                            terms: highlightTerms,
-                          }
-                        : null
+                  ) : (
+                    topicDetail.messages.map((message) => {
+                      const localMatched =
+                        Boolean(findState.query.trim()) &&
+                        findMatches.some((candidate) => candidate.message_id === message.message_id)
+                      const localFindQuery = localMatched ? findState.query.trim() : null
+                      const focusedSearchMessage =
+                        activeSearchResult?.message_id === message.message_id ? activeSearchResult : null
+                      const highlightTerms = uniqueStrings([
+                        ...(localFindQuery ? [localFindQuery] : []),
+                        ...(focusedSearchMessage
+                          ? activeSearchTerms.length > 0
+                            ? activeSearchTerms
+                            : sidebarSearchQuery.trim()
+                              ? tokenizeSearchQuery(sidebarSearchQuery)
+                              : []
+                          : []),
+                      ])
+                      const highlight =
+                        highlightTerms.length > 0
+                          ? {
+                              terms: highlightTerms,
+                            }
+                          : null
 
-                    return (
-                      <MessageCard
-                        key={message.message_id}
-                        message={message}
-                        highlight={highlight}
-                        focused={topicDetail.focus_message_id === message.message_id}
-                        localMatched={localMatched}
-                        localActive={activeFindMessageId === message.message_id}
-                        selectable={selectionMode}
-                        selected={selectedMessageIds.has(message.message_id)}
-                        onSelectedChange={(next) => onMessageSelectionChange(message.message_id, next)}
-                      />
-                    )
-                  })
-                )}
-              </div>
-            </ScrollArea>
+                      return (
+                        <MessageCard
+                          key={message.message_id}
+                          message={message}
+                          highlight={highlight}
+                          focused={topicDetail.focus_message_id === message.message_id}
+                          localMatched={localMatched}
+                          localActive={activeFindMessageId === message.message_id}
+                          selectable={selectionMode}
+                          selected={selectedMessageIds.has(message.message_id)}
+                          onSelectedChange={(next) => onMessageSelectionChange(message.message_id, next)}
+                        />
+                      )
+                    })
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
           </div>
         </CardContent>
       </section>
       <aside className="hidden min-h-0 flex-col overflow-hidden border-l border-border bg-[#202227] xl:flex">
-        {showSharedRail ? (
-          <Tabs
-            value={railMode}
-            onValueChange={(value) => setRailMode(value as TopicRailMode)}
-            className="flex min-h-0 flex-1 flex-col gap-0"
-          >
-            <CardHeader className="gap-3 border-b border-border px-4 py-3">
-              <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Topic rail</div>
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="map">Map</TabsTrigger>
-                <TabsTrigger value="inspector">Inspector</TabsTrigger>
-              </TabsList>
-            </CardHeader>
-            <TabsContent value="map" className="mt-0 flex min-h-0 flex-1 flex-col">
-              <ThreadMap
-                topicDetail={topicDetail}
-                markers={threadMapMarkers}
-                viewport={threadMapViewport}
-                onJumpToMessage={jumpToMessage}
-              />
-            </TabsContent>
-            <TabsContent value="inspector" className="mt-0 flex min-h-0 flex-1 flex-col">
-              <CardHeader className="border-b border-border px-4 py-3">
-                <CardTitle className="text-base">Topic metadata</CardTitle>
-              </CardHeader>
-              <TopicInspectorPanel topicDetail={topicDetail} />
-            </TabsContent>
-          </Tabs>
-        ) : (
-          <>
-            <CardHeader className="border-b border-border px-4 py-3">
-              <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Inspector</div>
-              <CardTitle className="text-base">Topic metadata</CardTitle>
-            </CardHeader>
-            <TopicInspectorPanel topicDetail={topicDetail} />
-          </>
-        )}
+        <>
+          <CardHeader className="border-b border-border px-4 py-3">
+            <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">Inspector</div>
+            <CardTitle className="text-base">Topic metadata</CardTitle>
+          </CardHeader>
+          <TopicInspectorPanel topicDetail={topicDetail} />
+        </>
       </aside>
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -748,13 +748,17 @@ function ThreadMap(props: {
               }
 
               dragStateRef.current = null
-              event.currentTarget.releasePointerCapture(event.pointerId)
+              if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                event.currentTarget.releasePointerCapture(event.pointerId)
+              }
               event.preventDefault()
               event.stopPropagation()
             }}
             onPointerCancel={(event) => {
               dragStateRef.current = null
-              event.currentTarget.releasePointerCapture(event.pointerId)
+              if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                event.currentTarget.releasePointerCapture(event.pointerId)
+              }
             }}
           />
         ) : null}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1092,9 +1092,6 @@ function TopicView(props: {
     if (resizeObserver) {
       resizeObserver.observe(viewport)
       resizeObserver.observe(threadList)
-      for (const node of threadList.querySelectorAll<HTMLElement>("[data-ab-message-id]")) {
-        resizeObserver.observe(node)
-      }
     } else {
       window.addEventListener("resize", measureMarkers)
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,12 +90,15 @@ type MessageHighlightSpec = {
   terms: string[]
 }
 
-type ThreadMapMarker = {
+type ThreadMapMeasuredMarker = {
   messageId: string
   seq: number
   sender: string
   top: number
   height: number
+}
+
+type ThreadMapMarker = ThreadMapMeasuredMarker & {
   focused: boolean
   localMatched: boolean
   localActive: boolean
@@ -915,10 +918,27 @@ function TopicView(props: {
   const threadListRef = useRef<HTMLDivElement | null>(null)
   const threadMapHideTimerRef = useRef<number | null>(null)
   const [isDesktopThreadMap, setIsDesktopThreadMap] = useState(false)
-  const [threadMapMarkers, setThreadMapMarkers] = useState<ThreadMapMarker[]>([])
+  const [threadMapMeasuredMarkers, setThreadMapMeasuredMarkers] = useState<
+    ThreadMapMeasuredMarker[]
+  >([])
   const [threadMapViewport, setThreadMapViewport] = useState<ThreadMapViewport | null>(null)
   const [threadMapQualifies, setThreadMapQualifies] = useState(false)
   const [threadMapVisible, setThreadMapVisible] = useState(false)
+  const threadMapMarkers = useMemo(
+    () =>
+      threadMapMeasuredMarkers.map((marker) => ({
+        ...marker,
+        focused: topicDetail.focus_message_id === marker.messageId,
+        localMatched: localMatchedMessageIds.has(marker.messageId),
+        localActive: activeFindMessageId === marker.messageId,
+      })),
+    [
+      activeFindMessageId,
+      localMatchedMessageIds,
+      threadMapMeasuredMarkers,
+      topicDetail.focus_message_id,
+    ]
+  )
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -995,17 +1015,7 @@ function TopicView(props: {
       return
     }
 
-    const messageMap = new Map(
-      topicDetail.messages.map((message) => [
-        message.message_id,
-        {
-          message,
-          focused: topicDetail.focus_message_id === message.message_id,
-          localMatched: localMatchedMessageIds.has(message.message_id),
-          localActive: activeFindMessageId === message.message_id,
-        },
-      ])
-    )
+    const messageMap = new Map(topicDetail.messages.map((message) => [message.message_id, message]))
 
     const updateViewport = () => {
       const nextQualifies = viewport.scrollHeight > viewport.clientHeight + 1
@@ -1038,7 +1048,7 @@ function TopicView(props: {
       setThreadMapQualifies(nextQualifies)
 
       if (!nextQualifies || viewport.scrollHeight <= 0) {
-        setThreadMapMarkers([])
+        setThreadMapMeasuredMarkers([])
         setThreadMapViewport(null)
         return
       }
@@ -1059,18 +1069,15 @@ function TopicView(props: {
         return [
           {
             messageId,
-            seq: entry.message.seq,
-            sender: entry.message.sender,
+            seq: entry.seq,
+            sender: entry.sender,
             top: clamp(node.offsetTop / viewport.scrollHeight, 0, 1),
             height: clamp(node.offsetHeight / viewport.scrollHeight, 0.0025, 1),
-            focused: entry.focused,
-            localMatched: entry.localMatched,
-            localActive: entry.localActive,
-          } satisfies ThreadMapMarker,
+          } satisfies ThreadMapMeasuredMarker,
         ]
       })
 
-      setThreadMapMarkers(nextMarkers)
+      setThreadMapMeasuredMarkers(nextMarkers)
       updateViewport()
     }
 
@@ -1101,13 +1108,7 @@ function TopicView(props: {
         window.removeEventListener("resize", measureMarkers)
       }
     }
-  }, [
-    activeFindMessageId,
-    isDesktopThreadMap,
-    localMatchedMessageIds,
-    topicDetail.focus_message_id,
-    topicDetail.messages,
-  ])
+  }, [isDesktopThreadMap, topicDetail.messages])
 
   function jumpToMessage(messageId: string) {
     revealThreadMap()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -670,6 +670,15 @@ function ThreadMap(props: {
   const { markers, viewport, visible, onJumpToMessage, onViewportDrag } = props
   const mapRef = useRef<HTMLDivElement | null>(null)
   const dragStateRef = useRef<{ grabOffset: number; viewportHeight: number } | null>(null)
+  const senderTones = useMemo(() => {
+    const tones = new Map<string, ThreadMapSenderTone>()
+    for (const marker of markers) {
+      if (!tones.has(marker.sender)) {
+        tones.set(marker.sender, getThreadMapSenderTone(marker.sender))
+      }
+    }
+    return tones
+  }, [markers])
 
   const moveViewportCursor = (clientY: number) => {
     const map = mapRef.current
@@ -777,7 +786,7 @@ function ThreadMap(props: {
           const slotHeight = Math.max(slotBottom - slotTop, 0.25)
           const glyphTop = clamp(((center - slotTop) / slotHeight) * 100, 0, 100)
           const visibleHeight = marker.localActive ? 11 : marker.focused ? 10 : marker.localMatched ? 9 : 8
-          const senderTone = getThreadMapSenderTone(marker.sender)
+          const senderTone = senderTones.get(marker.sender) ?? getThreadMapSenderTone(marker.sender)
           const tone = marker.localActive
             ? {
                 accentColor: "rgba(125, 211, 252, 0.95)",
@@ -921,6 +930,8 @@ function TopicView(props: {
   const threadViewportRef = useRef<HTMLDivElement | null>(null)
   const threadListRef = useRef<HTMLDivElement | null>(null)
   const threadMapHideTimerRef = useRef<number | null>(null)
+  const threadMapHideAtRef = useRef(0)
+  const threadMapHideTimerDueAtRef = useRef(0)
   const [isDesktopThreadMap, setIsDesktopThreadMap] = useState(false)
   const [threadMapMeasuredMarkers, setThreadMapMeasuredMarkers] = useState<
     ThreadMapMeasuredMarker[]
@@ -962,6 +973,8 @@ function TopicView(props: {
       window.clearTimeout(threadMapHideTimerRef.current)
       threadMapHideTimerRef.current = null
     }
+    threadMapHideAtRef.current = 0
+    threadMapHideTimerDueAtRef.current = 0
   })
 
   const scheduleThreadMapHide = useEffectEvent((delay = THREAD_MAP_AUTO_HIDE_MS) => {
@@ -969,11 +982,34 @@ function TopicView(props: {
       return
     }
 
-    clearThreadMapHideTimer()
-    threadMapHideTimerRef.current = window.setTimeout(() => {
-      setThreadMapVisible(false)
-      threadMapHideTimerRef.current = null
-    }, delay)
+    const armTimer = (timeout: number) => {
+      threadMapHideTimerDueAtRef.current = Date.now() + timeout
+      threadMapHideTimerRef.current = window.setTimeout(() => {
+        const remaining = threadMapHideAtRef.current - Date.now()
+        if (remaining > 0) {
+          armTimer(remaining)
+          return
+        }
+
+        setThreadMapVisible(false)
+        threadMapHideTimerRef.current = null
+        threadMapHideAtRef.current = 0
+        threadMapHideTimerDueAtRef.current = 0
+      }, timeout)
+    }
+
+    const nextHideAt = Date.now() + delay
+    threadMapHideAtRef.current = nextHideAt
+
+    if (threadMapHideTimerRef.current !== null) {
+      if (nextHideAt < threadMapHideTimerDueAtRef.current - 16) {
+        window.clearTimeout(threadMapHideTimerRef.current)
+        armTimer(delay)
+      }
+      return
+    }
+
+    armTimer(delay)
   })
 
   const revealThreadMap = useEffectEvent((delay = THREAD_MAP_AUTO_HIDE_MS) => {
@@ -988,19 +1024,11 @@ function TopicView(props: {
   useEffect(() => {
     if (!isDesktopThreadMap || !threadMapQualifies) {
       setThreadMapVisible(false)
-      if (threadMapHideTimerRef.current !== null) {
-        window.clearTimeout(threadMapHideTimerRef.current)
-        threadMapHideTimerRef.current = null
-      }
+      clearThreadMapHideTimer()
     }
 
-    return () => {
-      if (threadMapHideTimerRef.current !== null) {
-        window.clearTimeout(threadMapHideTimerRef.current)
-        threadMapHideTimerRef.current = null
-      }
-    }
-  }, [isDesktopThreadMap, threadMapQualifies])
+    return () => clearThreadMapHideTimer()
+  }, [clearThreadMapHideTimer, isDesktopThreadMap, threadMapQualifies])
 
   useEffect(() => {
     if (findState.open || activeFindMessageId || topicDetail.focus_message_id) {

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -6,8 +6,11 @@ import { cn } from "@/lib/utils"
 function ScrollArea({
   className,
   children,
+  viewportRef,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>
+}) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -15,6 +18,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -182,6 +182,9 @@ afterEach(() => {
 window.addEventListener("resize", () => {
   for (const mediaQuery of mediaQueries) {
     const nextMatches = matchesMediaQuery(mediaQuery.media)
+    if (nextMatches === mediaQuery.matches) {
+      continue
+    }
     mediaQuery.matches = nextMatches
     const event = { matches: nextMatches, media: mediaQuery.media } as MediaQueryListEvent
     mediaQuery.onchange?.(event)

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -47,9 +47,103 @@ class MockEventSource {
   }
 }
 
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = []
+  callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    MockResizeObserver.instances.push(this)
+  }
+
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver)
+  }
+}
+
+type MockMediaQueryList = {
+  media: string
+  matches: boolean
+  onchange: ((event: MediaQueryListEvent) => void) | null
+  addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void
+  removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void
+  addListener: (listener: EventListenerOrEventListenerObject) => void
+  removeListener: (listener: EventListenerOrEventListenerObject) => void
+  dispatchEvent: (event: Event) => boolean
+  _listeners: Set<EventListenerOrEventListenerObject>
+}
+
+function matchesMediaQuery(query: string): boolean {
+  const min = query.match(/min-width:\s*(\d+)px/)
+  if (min && window.innerWidth < Number(min[1])) {
+    return false
+  }
+
+  const max = query.match(/max-width:\s*(\d+)px/)
+  if (max && window.innerWidth > Number(max[1])) {
+    return false
+  }
+
+  return true
+}
+
+const mediaQueries = new Set<MockMediaQueryList>()
+
 Object.defineProperty(globalThis, "EventSource", {
   writable: true,
   value: MockEventSource,
+})
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  writable: true,
+  value: MockResizeObserver,
+})
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string): MediaQueryList => {
+    const mql: MockMediaQueryList = {
+      media: query,
+      matches: matchesMediaQuery(query),
+      onchange: null,
+      _listeners: new Set(),
+      addEventListener(type, listener) {
+        if (type === "change") {
+          this._listeners.add(listener)
+        }
+      },
+      removeEventListener(type, listener) {
+        if (type === "change") {
+          this._listeners.delete(listener)
+        }
+      },
+      addListener(listener) {
+        this._listeners.add(listener)
+      },
+      removeListener(listener) {
+        this._listeners.delete(listener)
+      },
+      dispatchEvent(event) {
+        for (const listener of this._listeners) {
+          if (typeof listener === "function") {
+            listener(event)
+          } else {
+            listener.handleEvent(event)
+          }
+        }
+        return true
+      },
+    }
+
+    mediaQueries.add(mql)
+    return mql as unknown as MediaQueryList
+  },
 })
 
 const storage = new Map<string, string>()
@@ -75,9 +169,22 @@ Object.defineProperty(window, "localStorage", {
 beforeEach(() => {
   window.localStorage.clear()
   MockEventSource.instances = []
+  MockResizeObserver.instances = []
+  mediaQueries.clear()
+  window.innerWidth = 1024
 })
 
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+})
+
+window.addEventListener("resize", () => {
+  for (const mediaQuery of mediaQueries) {
+    const nextMatches = matchesMediaQuery(mediaQuery.media)
+    mediaQuery.matches = nextMatches
+    const event = { matches: nextMatches, media: mediaQuery.media } as MediaQueryListEvent
+    mediaQuery.onchange?.(event)
+    mediaQuery.dispatchEvent(event as unknown as Event)
+  }
 })

--- a/frontend/tests/workbench.spec.ts
+++ b/frontend/tests/workbench.spec.ts
@@ -16,19 +16,21 @@ test("opens topics in tabs and navigates from sidebar search", async ({ page }) 
   await expect(page.locator("main").getByText("beta handoff summary")).toBeVisible()
 })
 
-test("renders the thread map for long desktop topics and toggles to the inspector", async ({ page }) => {
-  await page.setViewportSize({ width: 1440, height: 900 })
+test("reveals the thread-map overlay for long desktop topics while keeping the inspector rail", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 700 })
   await page.goto("/")
 
   await page.getByRole("button", { name: /Alpha review/i }).click()
+  await page.locator("[data-ab-topic-thread-scroll-area='true']").evaluate((element) => {
+    ;(element as HTMLElement).style.height = "320px"
+  })
 
-  await expect(page.getByRole("tab", { name: "Map" })).toBeVisible()
+  await expect(page.getByText("Topic metadata")).toBeVisible()
+  await expect(page.locator("[data-ab-thread-map-hotspot='true']")).toBeAttached()
+  await expect(page.locator("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "false")
+
+  await page.locator("[data-ab-thread-map-hotspot='true']").hover()
+  await expect(page.locator("[data-ab-thread-map='true']")).toHaveAttribute("data-visible", "true")
   await expect(page.locator("[data-ab-thread-map='true']")).toBeVisible()
   await expect(page.locator("[data-ab-thread-map-marker]").first()).toBeVisible()
-
-  await page.getByRole("tab", { name: "Inspector" }).click()
-  await expect(page.getByText("Topic metadata")).toBeVisible()
-
-  await page.getByRole("tab", { name: "Map" }).click()
-  await expect(page.locator("[data-ab-thread-map='true']")).toBeVisible()
 })

--- a/frontend/tests/workbench.spec.ts
+++ b/frontend/tests/workbench.spec.ts
@@ -15,3 +15,20 @@ test("opens topics in tabs and navigates from sidebar search", async ({ page }) 
   await expect(page).toHaveURL(/\/topics\/.+\?focus=/)
   await expect(page.locator("main").getByText("beta handoff summary")).toBeVisible()
 })
+
+test("renders the thread map for long desktop topics and toggles to the inspector", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/")
+
+  await page.getByRole("button", { name: /Alpha review/i }).click()
+
+  await expect(page.getByRole("tab", { name: "Map" })).toBeVisible()
+  await expect(page.locator("[data-ab-thread-map='true']")).toBeVisible()
+  await expect(page.locator("[data-ab-thread-map-marker]").first()).toBeVisible()
+
+  await page.getByRole("tab", { name: "Inspector" }).click()
+  await expect(page.getByText("Topic metadata")).toBeVisible()
+
+  await page.getByRole("tab", { name: "Map" }).click()
+  await expect(page.locator("[data-ab-thread-map='true']")).toBeVisible()
+})

--- a/tests/fixtures/seed_web_ui_db.py
+++ b/tests/fixtures/seed_web_ui_db.py
@@ -34,7 +34,7 @@ def main() -> None:
     beta = db.topic_create(name="Beta thread", metadata=None, mode="new")
 
     send(db, topic_id=alpha.topic_id, sender="reviewer", content="hello from alpha")
-    for index in range(1, 11):
+    for index in range(1, 21):
         sender = "reviewer" if index % 2 == 0 else "architect"
         send(
             db,

--- a/tests/fixtures/seed_web_ui_db.py
+++ b/tests/fixtures/seed_web_ui_db.py
@@ -34,6 +34,14 @@ def main() -> None:
     beta = db.topic_create(name="Beta thread", metadata=None, mode="new")
 
     send(db, topic_id=alpha.topic_id, sender="reviewer", content="hello from alpha")
+    for index in range(1, 11):
+        sender = "reviewer" if index % 2 == 0 else "architect"
+        send(
+            db,
+            topic_id=alpha.topic_id,
+            sender=sender,
+            content=f"alpha checkpoint {index}: thread-map fixture message with enough text to wrap in the desktop topic view.",
+        )
     send(db, topic_id=beta.topic_id, sender="architect", content="beta handoff summary")
 
 


### PR DESCRIPTION
## Summary
- add a desktop-only thread map for overflowing active topic tabs
- share the right rail between the new map and the existing inspector, while keeping inspector-only behavior for short topics
- keep the map in sync with local thread find, focused messages, load-earlier prepends, and live topic updates without observer churn
- keep thread-map markers clickable without adding them to the normal tab order

## Testing
- `pnpm --dir frontend test`
- `pnpm --dir frontend build`
- `CI=1 pnpm --dir frontend test:e2e`
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest`
- `git diff --check`

Closes #43
