### PR TITLE
release: prepare 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.3] - Unreleased
+## [0.5.0] - 2026-04-24
 
 ### Added
 
 - Added a Fumadocs-powered GitHub Pages site generated from the repo docs, including repo-aware
   base-path handling, search, Open Graph routes, and LLM-friendly text outputs.
+- Added a desktop thread map overlay for long Web UI topics, with hover reveal, click-to-jump,
+  drag-to-scroll, local-find markers, and focused-message markers.
 
 ### Fixed
 
@@ -15,6 +17,8 @@ All notable changes to this project will be documented in this file.
   or drifting behind the SSE event stream.
 - The topic stream handling now ignores no-op presence updates, bounds catch-up work, and hardens
   ordering so browser sessions recover more cleanly under concurrent delete and refresh activity.
+- The thread map now keeps measurement, marker state, and drag geometry separate so long topics
+  avoid observer churn, timer churn, overlapping marker bands, and unreachable bottom scroll ranges.
 
 ### Documentation
 
@@ -30,12 +34,13 @@ All notable changes to this project will be documented in this file.
 
 ### Upgrade
 
-- Upgrade to `0.4.3` to pick up the live-delete workbench resync fix and the latest docs-site
-  refresh. Protocol and package interfaces otherwise remain aligned with `0.4.2`.
+- Upgrade to `0.5.0` to pick up the live-delete workbench resync fix, the latest docs-site refresh,
+  and the Web UI thread map for navigating long topics. Protocol and package interfaces otherwise
+  remain aligned with `0.4.2`.
 - To preview this release explicitly with `uvx`, run:
 
   ```bash
-  uvx --from "agent-bus-mcp[web]==0.4.3" agent-bus serve
+  uvx --from "agent-bus-mcp[web]==0.5.0" agent-bus serve
   ```
 
 ## [0.4.2] - 2026-04-12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-bus-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "fastembed",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bus-core"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ The fastest path is to install Agent Bus MCP as an MCP server in your client and
 natural-language prompts.
 
 ```bash
-export AGENT_BUS_VERSION="0.4.3"
+export AGENT_BUS_VERSION="0.5.0"
 npx install-mcp "uvx --from agent-bus-mcp==$AGENT_BUS_VERSION agent-bus" --name agent-bus --client claude-code
 ```
 
-Replace `0.4.3` if you want a different release. For direct setup:
+Replace `0.5.0` if you want a different release. For direct setup:
 
 ```bash
 # Codex

--- a/docs/how-to/install-and-configure-agent-bus.md
+++ b/docs/how-to/install-and-configure-agent-bus.md
@@ -12,7 +12,7 @@ Start with the published package unless you are developing Agent Bus MCP itself.
 Set a version once, then verify that the published package runs:
 
 ```bash
-export AGENT_BUS_VERSION="0.4.3"
+export AGENT_BUS_VERSION="0.5.0"
 uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus --help
 ```
 
@@ -29,14 +29,14 @@ For long-lived client configuration, pin the package version.
 claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
-Equivalent `.mcp.json` entry (replace `0.4.3` if you want a different release):
+Equivalent `.mcp.json` entry (replace `0.5.0` if you want a different release):
 
 ```json
 {
   "mcpServers": {
     "agent-bus": {
       "command": "uvx",
-      "args": ["--from", "agent-bus-mcp==0.4.3", "agent-bus"],
+      "args": ["--from", "agent-bus-mcp==0.5.0", "agent-bus"],
       "env": {}
     }
   }
@@ -49,12 +49,12 @@ Equivalent `.mcp.json` entry (replace `0.4.3` if you want a different release):
 codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
-Equivalent `~/.codex/config.toml` entry (replace `0.4.3` if you want a different release):
+Equivalent `~/.codex/config.toml` entry (replace `0.5.0` if you want a different release):
 
 ```toml
 [mcp_servers.agent-bus]
 command = "uvx"
-args = ["--from", "agent-bus-mcp==0.4.3", "agent-bus"]
+args = ["--from", "agent-bus-mcp==0.5.0", "agent-bus"]
 ```
 
 ### OpenCode
@@ -65,7 +65,7 @@ args = ["--from", "agent-bus-mcp==0.4.3", "agent-bus"]
   "mcp": {
     "agent-bus": {
       "type": "local",
-      "command": ["uvx", "--from", "agent-bus-mcp==0.4.3", "agent-bus"],
+      "command": ["uvx", "--from", "agent-bus-mcp==0.5.0", "agent-bus"],
       "enabled": true
     }
   }

--- a/docs/how-to/use-the-web-ui.md
+++ b/docs/how-to/use-the-web-ui.md
@@ -14,7 +14,7 @@ You need a running Agent Bus MCP database and a frontend bundle.
 From a published package:
 
 ```bash
-export AGENT_BUS_VERSION="0.4.3"
+export AGENT_BUS_VERSION="0.5.0"
 uvx --from "agent-bus-mcp[web]==$AGENT_BUS_VERSION" agent-bus serve
 ```
 

--- a/docs/tutorials/first-topic-between-two-peers.md
+++ b/docs/tutorials/first-topic-between-two-peers.md
@@ -20,7 +20,7 @@ Make sure both clients can reach the same local Agent Bus MCP runtime.
 Example:
 
 ```bash
-export AGENT_BUS_VERSION="0.4.3"
+export AGENT_BUS_VERSION="0.5.0"
 codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-bus-mcp"
-version = "0.4.3"
+version = "0.5.0"
 description = "Local SQLite-backed MCP bus for peer coding agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/spec.md
+++ b/spec.md
@@ -183,7 +183,7 @@ Constraints:
 
 - `ok: true`
 - `spec_version: string`
-- `package_version: string` (installed package/runtime version, for example `0.4.3`)
+- `package_version: string` (installed package/runtime version, for example `0.5.0`)
 
 ### 4.3 `sync()` semantics
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agent-bus-mcp"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Prepare Agent Bus MCP 0.5.0 release metadata and docs
- Update lockfiles, spec examples, README, and install docs to 0.5.0
- Document the thread map and docs-site release notes in the changelog

## Validation
- `uv run ty check`
- `uv run ruff check`
- `uv run pytest -q`
- `cargo check`
- `GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp pnpm --dir site build`
- `uv build`
- `git diff --check`