### PR TITLE
docs: add docs-site skill

### DIFF
--- a/.agents/skills/agent-bus-docs-site/SKILL.md
+++ b/.agents/skills/agent-bus-docs-site/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: agent-bus-docs-site
+description: Use when changing the Agent Bus Fumadocs website, docs generator, site metadata, GitHub Pages export behavior, or Markdown docs that feed agentbusmcp.com.
+---
+
+# Agent Bus Docs Site
+
+Use this skill for Agent Bus website and docs-site work. The important contract is that the
+repository Markdown remains the source of truth; the Fumadocs content tree is generated output.
+
+Read [references/generator-contract.md](references/generator-contract.md) before changing the
+generator or debugging site content drift.
+
+## Source Of Truth
+
+- Author durable documentation in `docs/**/*.md`, `spec.md`, and `CHANGELOG.md`.
+- Do not hand-edit `site/content/docs/` or `site/public/docs-assets/`; regenerate them.
+- Keep website copy that explains product positioning aligned with the authored Markdown docs when
+  the same facts appear in both places.
+- Treat generated docs routes as public site behavior, not just build artifacts.
+
+## Main Workflow
+
+1. Edit the source Markdown or site component that owns the change.
+2. If source docs changed, run the generator through the site script:
+
+   ```bash
+   pnpm --dir site run generate:content
+   ```
+
+3. If the generator changed, run its focused tests:
+
+   ```bash
+   uv run pytest tests/test_generate_fumadocs_site.py
+   ```
+
+4. For site or routing changes, build with the GitHub Pages base path:
+
+   ```bash
+   GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp pnpm --dir site build
+   ```
+
+5. If the change affects release snippets, install commands, or package versions, check all docs
+   copies with `rg` before committing.
+
+## Generator Boundaries
+
+- `scripts/generate_fumadocs_site.py` converts repository docs into the Fumadocs publish tree.
+- `site/scripts/generate-content.mjs` is the Node wrapper used by `pnpm --dir site build` and
+  `pnpm --dir site dev`.
+- `site/package.json` must keep `generate:content` before `fumadocs-mdx` and Next.js commands.
+- The generator owns section ordering, `meta.json`, special pages, asset copying, and link rewriting.
+- Site React components own presentation, home page layout, search UI, OG routes, and llms routes.
+
+## Review Checklist
+
+- Markdown links generated from `docs/README.md` still resolve under `/docs`.
+- Relative links are rewritten to the generated route, not left pointing outside the docs app.
+- Asset paths under `docs/images/` are copied to `site/public/docs-assets/images/`.
+- Diataxis section pages are represented through metadata, not by publishing every section README.
+- `spec.md` maps to `reference/implementation-spec.mdx`.
+- `CHANGELOG.md` maps to `reference/changelog.mdx`.
+- GitHub Pages export still uses the repository base path in CI-like builds.
+
+## Common Failure Shields
+
+- Symptom: local build passes but a docs front-door link escapes `/docs`.
+  Cause: a relative Markdown link was emitted unchanged.
+  Fix: update link rewriting or source link shape, then verify with generator tests and a site build.
+- Symptom: website preview works locally but GitHub Pages assets 404.
+  Cause: base path or static export settings drifted.
+  Fix: build with `GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp`.
+- Symptom: docs content differs from Markdown source.
+  Cause: generated files were edited or stale.
+  Fix: discard generated edits if they are tracked accidentally, then rerun `pnpm --dir site run generate:content`.

--- a/.agents/skills/agent-bus-docs-site/references/generator-contract.md
+++ b/.agents/skills/agent-bus-docs-site/references/generator-contract.md
@@ -1,0 +1,77 @@
+# Generator Contract
+
+This repo uses a custom Markdown-to-Fumadocs pipeline. The goal is to keep docs authored in normal
+repo Markdown while publishing a richer Fumadocs site.
+
+## Key Files
+
+- `scripts/generate_fumadocs_site.py`: canonical content generator.
+- `tests/test_generate_fumadocs_site.py`: generator regression tests.
+- `site/scripts/generate-content.mjs`: Node entrypoint that finds Python and runs the generator.
+- `site/source.config.ts`: Fumadocs source config for `site/content/docs`.
+- `site/next.config.mjs`: static export and base-path integration.
+- `site/base-path.shared.js`: shared repo-aware base-path helper.
+- `site/src/lib/shared.ts`: site helpers, including base-path URL handling.
+
+## Generated Tree
+
+The generator writes:
+
+- `site/content/docs/**/*.mdx`
+- `site/content/docs/**/meta.json`
+- `site/public/docs-assets/images/**`
+
+Do not treat these as authoring surfaces. They should be reproducible from:
+
+- `docs/**/*.md`
+- `spec.md`
+- `CHANGELOG.md`
+- `docs/images/**`
+
+## Mapping Rules
+
+- `docs/README.md` becomes `site/content/docs/index.mdx`.
+- `docs/tutorials/*.md` becomes `site/content/docs/tutorials/*.mdx`.
+- `docs/how-to/*.md` becomes `site/content/docs/how-to/*.mdx`.
+- `docs/reference/*.md` becomes `site/content/docs/reference/*.mdx`.
+- `docs/explanation/*.md` becomes `site/content/docs/explanation/*.mdx`.
+- `spec.md` becomes `site/content/docs/reference/implementation-spec.mdx`.
+- `CHANGELOG.md` becomes `site/content/docs/reference/changelog.mdx`.
+- `docs/diataxis-migration-matrix.md` is intentionally excluded.
+
+Section `README.md` files are used for titles and metadata but are not published as normal pages.
+
+## Content Rewrites
+
+The generator is responsible for:
+
+- stripping duplicate leading H1s where the Fumadocs page shell supplies the title
+- extracting descriptions for metadata
+- rewriting Markdown links to generated routes
+- rewriting Markdown and HTML image sources into `docs-assets`
+- wrapping selected tutorial and install-guide sections with site-specific presentation classes
+- writing deterministic `meta.json` files for root and section ordering
+
+Do not add one-off content patches in generated MDX when the source Markdown or generator rule should
+own the behavior.
+
+## Validation
+
+Run focused generator tests after changing mapping, link rewriting, assets, or metadata:
+
+```bash
+uv run pytest tests/test_generate_fumadocs_site.py
+```
+
+Run the CI-like site build after changing routes, base-path behavior, Fumadocs config, or home/docs
+layout:
+
+```bash
+GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp pnpm --dir site build
+```
+
+If `site/node_modules` is missing in a fresh worktree, install site dependencies first:
+
+```bash
+pnpm --dir site install --frozen-lockfile
+```


### PR DESCRIPTION
## Summary
- Add a repo-local Agent Bus docs-site skill for future website/docs work
- Capture the Markdown-as-source-of-truth contract for the custom Fumadocs generator
- Document generator boundaries, route/link checks, GitHub Pages base-path validation, and common failure modes

## Validation
- `git diff --check`
- `git diff --cached --check` before commit