### PR TITLE
fix(site): prevent mobile horizontal overflow

### DIFF
--- a/site/src/app/global.css
+++ b/site/src/app/global.css
@@ -17,10 +17,21 @@
 
 html {
   scrollbar-gutter: stable;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 body {
   font-family: var(--font-sans), sans-serif;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+@supports (overflow: clip) {
+  html,
+  body {
+    overflow-x: clip;
+  }
 }
 
 code,

--- a/site/src/components/how-it-works.tsx
+++ b/site/src/components/how-it-works.tsx
@@ -40,30 +40,32 @@ export function HowItWorks() {
           </p>
         </div>
 
-        <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
-          <ol className="space-y-4">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+          <ol className="min-w-0 space-y-4">
             {STEPS.map((step) => (
               <li
                 key={step.number}
-                className="group rounded-2xl border border-fd-border bg-fd-card p-5 transition hover:border-[color:var(--color-accent-amber-soft)] hover:shadow-sm"
+                className="group min-w-0 rounded-2xl border border-fd-border bg-fd-card p-5 transition hover:border-[color:var(--color-accent-amber-soft)] hover:shadow-sm"
               >
-                <div className="flex items-baseline gap-3">
+                <div className="flex min-w-0 items-baseline gap-3">
                   <span className="font-mono text-xs font-medium tracking-[0.18em] text-[color:var(--color-accent-amber)]">
                     {step.number}
                   </span>
-                  <h3 className="text-lg font-semibold text-fd-foreground">{step.title}</h3>
+                  <h3 className="min-w-0 text-lg font-semibold text-fd-foreground">
+                    {step.title}
+                  </h3>
                 </div>
                 <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
                   {step.description}
                 </p>
-                <pre className="mt-3 overflow-x-auto rounded-md border border-fd-border bg-fd-muted/60 px-3 py-2 font-mono text-[12.5px] leading-5 text-fd-foreground/85">
+                <pre className="mt-3 max-w-full overflow-x-auto rounded-md border border-fd-border bg-fd-muted/60 px-3 py-2 font-mono text-[12.5px] leading-5 text-fd-foreground/85">
                   <code>{step.code}</code>
                 </pre>
               </li>
             ))}
           </ol>
 
-          <div className="lg:sticky lg:top-24">
+          <div className="min-w-0 lg:sticky lg:top-24">
             <TopicFlowDiagram />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Prevent mobile horizontal page panning by clipping root horizontal overflow.
- Let the home page "How it works" grid and cards shrink below their min-content width so code snippets scroll inside their cards instead of widening the page.

## Validation
- Verified mobile widths 320, 360, 375, 390, 414, and 430 px: `documentElement.scrollWidth` equals viewport width and attempted horizontal scroll stays at `0`.
- `GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp pnpm --dir site build`
- `pnpm --dir site types:check`
