### PR TITLE
release: prepare 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2026-08-15
+
+### Fixed
+
+- Constrained the MCP Python SDK dependency to the compatible 1.x API so clean installations do
+  not select MCP 2.x while Agent Bus still uses the v1 `FastMCP` interface.
+
+### Upgrade
+
+- Upgrade to `0.5.1` if a clean installation fails after the MCP 2.x release.
+- To verify this release explicitly with `uvx`, run:
+
+  ```bash
+  uvx --from agent-bus-mcp==0.5.1 agent-bus --help
+  ```
+
 ## [0.5.0] - 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-bus-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fastembed",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-bus-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ The fastest path is to install Agent Bus MCP as an MCP server in your client and
 natural-language prompts.
 
 ```bash
-export AGENT_BUS_VERSION="0.5.0"
+export AGENT_BUS_VERSION="0.5.1"
 npx install-mcp "uvx --from agent-bus-mcp==$AGENT_BUS_VERSION agent-bus" --name agent-bus --client claude-code
 ```
 
-Replace `0.5.0` if you want a different release. For direct setup:
+Replace `0.5.1` if you want a different release. For direct setup:
 
 ```bash
 # Codex

--- a/docs/how-to/install-and-configure-agent-bus.md
+++ b/docs/how-to/install-and-configure-agent-bus.md
@@ -12,7 +12,7 @@ Start with the published package unless you are developing Agent Bus MCP itself.
 Set a version once, then verify that the published package runs:
 
 ```bash
-export AGENT_BUS_VERSION="0.5.0"
+export AGENT_BUS_VERSION="0.5.1"
 uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus --help
 ```
 
@@ -29,14 +29,14 @@ For long-lived client configuration, pin the package version.
 claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
-Equivalent `.mcp.json` entry (replace `0.5.0` if you want a different release):
+Equivalent `.mcp.json` entry (replace `0.5.1` if you want a different release):
 
 ```json
 {
   "mcpServers": {
     "agent-bus": {
       "command": "uvx",
-      "args": ["--from", "agent-bus-mcp==0.5.0", "agent-bus"],
+      "args": ["--from", "agent-bus-mcp==0.5.1", "agent-bus"],
       "env": {}
     }
   }
@@ -49,12 +49,12 @@ Equivalent `.mcp.json` entry (replace `0.5.0` if you want a different release):
 codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```
 
-Equivalent `~/.codex/config.toml` entry (replace `0.5.0` if you want a different release):
+Equivalent `~/.codex/config.toml` entry (replace `0.5.1` if you want a different release):
 
 ```toml
 [mcp_servers.agent-bus]
 command = "uvx"
-args = ["--from", "agent-bus-mcp==0.5.0", "agent-bus"]
+args = ["--from", "agent-bus-mcp==0.5.1", "agent-bus"]
 ```
 
 ### OpenCode
@@ -65,7 +65,7 @@ args = ["--from", "agent-bus-mcp==0.5.0", "agent-bus"]
   "mcp": {
     "agent-bus": {
       "type": "local",
-      "command": ["uvx", "--from", "agent-bus-mcp==0.5.0", "agent-bus"],
+      "command": ["uvx", "--from", "agent-bus-mcp==0.5.1", "agent-bus"],
       "enabled": true
     }
   }

--- a/docs/how-to/use-the-web-ui.md
+++ b/docs/how-to/use-the-web-ui.md
@@ -14,7 +14,7 @@ You need a running Agent Bus MCP database and a frontend bundle.
 From a published package:
 
 ```bash
-export AGENT_BUS_VERSION="0.5.0"
+export AGENT_BUS_VERSION="0.5.1"
 uvx --from "agent-bus-mcp[web]==$AGENT_BUS_VERSION" agent-bus serve
 ```
 

--- a/docs/tutorials/first-topic-between-two-peers.md
+++ b/docs/tutorials/first-topic-between-two-peers.md
@@ -20,7 +20,7 @@ Make sure both clients can reach the same local Agent Bus MCP runtime.
 Example:
 
 ```bash
-export AGENT_BUS_VERSION="0.5.0"
+export AGENT_BUS_VERSION="0.5.1"
 codex mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 claude mcp add agent-bus -- uvx --from "agent-bus-mcp==$AGENT_BUS_VERSION" agent-bus
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-bus-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local SQLite-backed MCP bus for peer coding agents"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "click>=8.3.1",
-  "mcp>=1.25.0",
+  "mcp>=1.25.0,<2.0",
   "numpy>=2.4.1",
 ]
 

--- a/spec.md
+++ b/spec.md
@@ -183,7 +183,7 @@ Constraints:
 
 - `ok: true`
 - `spec_version: string`
-- `package_version: string` (installed package/runtime version, for example `0.5.0`)
+- `package_version: string` (installed package/runtime version, for example `0.5.1`)
 
 ### 4.3 `sync()` semantics
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agent-bus-mcp"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -31,7 +31,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.128.0" },
-    { name = "mcp", specifier = ">=1.25.0" },
+    { name = "mcp", specifier = ">=1.25.0,<2.0" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.40.0" },
 ]


### PR DESCRIPTION
## Summary

- Constrain the MCP Python SDK to `>=1.25.0,<2.0` so clean installs stay on the compatible v1 API.
- Bump the Python and Rust package versions to 0.5.1.
- Refresh lock metadata, current install examples, protocol version examples, and release notes.

Closes #49

## Validation

- `uv lock --check`
- `cargo check --locked`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q` (107 passed)
- Unlocked resolution selects `mcp==1.29.0`.
- Built wheel metadata reports `Version: 0.5.1` and `Requires-Dist: mcp>=1.25.0,<2.0`.
- `pnpm --dir site run generate:content`
- `GITHUB_ACTIONS=true GITHUB_REPOSITORY=alessandrobologna/agent-bus-mcp pnpm --dir site build`
- `git diff --check`